### PR TITLE
Load auction table in highest-bid order

### DIFF
--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -78,7 +78,7 @@ export default function AuctionSite() {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Slot | null>(null);
   const [status, setStatus] = useState("");
-  const [sort, setSort] = useState("number");
+  const [sort, setSort] = useState("price");
   const [showAll, setShowAll] = useState(false);
   const slots = useMemo(
     () => activeSlots(snapshot.placements),


### PR DESCRIPTION
## Summary
- default the “A little space. An open-ended race.” table to current-bid sorting
- show claimed placements from highest bid to lowest on initial load
- retain the existing header control for switching back to spot order

## Verification
- `npm run check`
  - TypeScript passed
  - 34 tests passed
  - Cloudflare/OpenNext production build passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads the auction table sorted by current bid instead of spot number, so the most competitive placements appear first. The header control still lets users switch back to spot order.

<sup>Written for commit f30250ae02c5c240efb4725a984bf654baa667ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

