### PR TITLE
Show historic page views beside online count

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -123,3 +123,29 @@ A $4 sandbox replacement verified the advertiser profile: a 102-character messag
 Browser-only auction fixtures verified the default camera on all five faces, the empty-auction fallback, tied bids, manual angle and OrbitControls overrides during live leader changes, and Reset returning to the latest leader. These fixtures did not change stored placements or create payments.
 
 Vehicle attribution is retained at `/credits`; font licensing is included with the model. All fonts, model textures, and Draco decoders used by the site are self-hosted.
+
+## Historic page-view counter
+
+The hero displays Cloudflare Web Analytics page views next to the active browser
+connection count. This is page views (including repeat views), not unique people.
+The source is site `a9425d0f08934c0b919b4c5ff11fb5f7`, with known bots excluded,
+starting September 9, 2026 UTC, the date tracking was enabled. The GraphQL `count`
+is already sampling-adjusted, so it is not multiplied by the sampling interval.
+
+Before merging this feature, store a dedicated Cloudflare token with account
+Analytics Read access as the production Worker secret `CLOUDFLARE_ANALYTICS_TOKEN`.
+Do not use an expiring Wrangler login token. Keep the PR in draft until this is
+configured. Secret configuration does not authorize manually deploying Worker code.
+
+Cloudflare cron runs at minute 7 each hour. It calls the auction object through its
+private Worker binding; visitors cannot trigger a sync. Daily aggregates persist
+in Durable Object SQLite. The current day and previous two days are replaced on
+refresh to incorporate delayed data without double counting. Older days remain
+stored after Cloudflare retention expires. A bounded catch-up processes up to four
+seven-day batches per run; failures preserve the last successfully published total.
+The counter stays hidden until the first complete backfill. Staging has no cron and
+cannot sync production analytics. After the Git build deploys, verify the first cron
+succeeds and `/api/auction` reports `totalViews` matching the stored daily sum.
+
+Cloudflare figures can be sampled and omit blocked/missed beacons. They represent
+recorded views since tracking began, not a guaranteed census of every visitor.

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -137,7 +137,7 @@ Analytics Read access as the production Worker secret `CLOUDFLARE_ANALYTICS_TOKE
 Do not use an expiring Wrangler login token. Keep the PR in draft until this is
 configured. Secret configuration does not authorize manually deploying Worker code.
 
-Cloudflare cron runs at minute 7 each hour. It calls the auction object through its
+Cloudflare cron runs every five minutes. It calls the auction object through its
 private Worker binding; visitors cannot trigger a sync. Daily aggregates persist
 in Durable Object SQLite. The current day and previous two days are replaced on
 refresh to incorporate delayed data without double counting. Older days remain

--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -160,6 +160,16 @@ input[type="checkbox"] {
   gap: 8px;
   color: #6e736a;
   font-size: 13px;
+  flex-wrap: wrap;
+}
+.live-status,
+.audience-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: inherit;
+}
+.audience-counts {
+  white-space: nowrap;
 }
 .tiny-dot {
   display: inline-block;
@@ -1827,8 +1837,9 @@ fieldset {
     font-size: 10px;
     gap: 5px;
   }
-  .live-indicator > span:last-child {
-    display: none;
+  .audience-counts {
+    flex-basis: 100%;
+    justify-content: center;
   }
   .muted-separator {
     display: none;

--- a/apps/website/src/app/privacy/page.tsx
+++ b/apps/website/src/app/privacy/page.tsx
@@ -54,8 +54,10 @@ export default function Privacy() {
         IP-based request counters help prevent abuse; the application expires
         them after two minutes. Hosting providers may retain operational logs
         under their own policies. The online counter counts active browser
-        connections, not identifiable people. We do not add advertising trackers
-        or analytics cookies.
+        connections, not identifiable people. Cloudflare Web Analytics measures
+        page views without analytics cookies. We retain daily aggregate view
+        counts to display the historic total, excluding known bots. We do not
+        add advertising trackers or analytics cookies.
       </p>
       <h2>Retention and requests</h2>
       <p>

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -210,19 +210,31 @@ export default function AuctionSite() {
       <main>
         <section className="hero">
           <div className="live-indicator">
-            <span className={connected ? "tiny-dot" : "tiny-dot muted"} />
-            {snapshot.paymentMode === "test"
-              ? "Test drive · no real payments"
-              : connected
-                ? "The auction is always live"
-                : loaded
-                  ? "Reconnecting live updates"
-                  : "Connecting to the garage"}
-            <span className="muted-separator">·</span>
-            <span>
-              {connected && snapshot.online > 0
-                ? `${snapshot.online} online now`
-                : `${slots.length} spots. One tiny driver.`}
+            <span className="live-status">
+              <span className={connected ? "tiny-dot" : "tiny-dot muted"} />
+              {snapshot.paymentMode === "test"
+                ? "Test drive · no real payments"
+                : connected
+                  ? "The auction is always live"
+                  : loaded
+                    ? "Reconnecting live updates"
+                    : "Connecting to the garage"}
+            </span>
+            <span className="audience-counts">
+              <span className="muted-separator">·</span>
+              <span>
+                {connected && snapshot.online > 0
+                  ? `${snapshot.online} online now`
+                  : `${slots.length} spots. One tiny driver.`}
+              </span>
+              {snapshot.totalViews != null && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span title="Page views recorded by Cloudflare Web Analytics since tracking began; known bots excluded. Updated hourly.">
+                    {snapshot.totalViews.toLocaleString("en-US")} total views
+                  </span>
+                </>
+              )}
             </span>
           </div>
           <h1>

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -230,7 +230,7 @@ export default function AuctionSite() {
               {snapshot.totalViews != null && (
                 <>
                   <span aria-hidden="true">·</span>
-                  <span title="Page views recorded by Cloudflare Web Analytics since tracking began; known bots excluded. Updated hourly.">
+                  <span title="Page views recorded by Cloudflare Web Analytics since tracking began; known bots excluded. Updated every five minutes.">
                     {snapshot.totalViews.toLocaleString("en-US")} total views
                   </span>
                 </>

--- a/apps/website/src/lib/auction.ts
+++ b/apps/website/src/lib/auction.ts
@@ -63,6 +63,7 @@ export type AuctionSnapshot = {
   totalRaised: number;
   totalPurchases: number;
   online: number;
+  totalViews: number | null;
   paymentsEnabled: boolean;
   paymentMode: "live" | "test" | "unavailable";
 };
@@ -76,6 +77,7 @@ export const emptySnapshot: AuctionSnapshot = {
   totalRaised: 0,
   totalPurchases: 0,
   online: 0,
+  totalViews: null,
   paymentsEnabled: false,
   paymentMode: "unavailable",
 };

--- a/apps/website/tests/page-views.test.ts
+++ b/apps/website/tests/page-views.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { build } from "esbuild";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Miniflare, Response } from "miniflare";
+
+let mf: Miniflare;
+let directory: string;
+let count = 12;
+let fail = false;
+let invalid = false;
+let requests = 0;
+let stub: {
+  syncPageViews(): Promise<void>;
+  testSql(
+    query: string,
+    ...values: (string | number | null)[]
+  ): Promise<Record<string, unknown>[]>;
+};
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(tmpdir(), "fly-views-"));
+  const script = join(directory, "worker.mjs");
+  await build({
+    entryPoints: ["tests/fixtures/auction-worker.ts"],
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    outfile: script,
+    external: ["cloudflare:workers", "node:*"],
+  });
+  mf = new Miniflare({
+    modules: true,
+    modulesRoot: directory,
+    scriptPath: script,
+    compatibilityDate: "2026-08-01",
+    compatibilityFlags: ["nodejs_compat"],
+    durableObjects: { AUCTION: { className: "Auction", useSQLite: true } },
+    r2Buckets: ["ARTWORK"],
+    bindings: {
+      SITE_URL: "https://thedrivingfly.com",
+      CLOUDFLARE_ANALYTICS_TOKEN: "test-only",
+    },
+    outboundService: async (request: import("miniflare").Request) => {
+      requests++;
+      expect(request.url).toBe("https://api.cloudflare.com/client/v4/graphql");
+      expect(request.headers.get("authorization")).toBe("Bearer test-only");
+      const body = (await request.json()) as {
+        query: string;
+        variables: { from: string; to: string };
+      };
+      expect(body.query).toContain("bot: 0");
+      expect(body.query).toContain("a9425d0f08934c0b919b4c5ff11fb5f7");
+      if (fail)
+        return Response.json({
+          errors: [{ message: "Permission denied" }],
+          data: null,
+        });
+      return Response.json({
+        errors: null,
+        data: {
+          viewer: {
+            accounts: [
+              {
+                rumPageloadEventsAdaptiveGroups: [
+                  {
+                    count: invalid ? -1 : count,
+                    dimensions: { date: body.variables.from.slice(0, 10) },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      });
+    },
+  });
+  const ns = await mf.getDurableObjectNamespace("AUCTION");
+  stub = ns.get(ns.idFromName("the-driving-fly-v1")) as unknown as typeof stub;
+});
+afterAll(async () => {
+  await mf?.dispose();
+  await rm(directory, { recursive: true, force: true });
+});
+const snapshot = async () =>
+  (await (
+    await mf.dispatchFetch("https://thedrivingfly.com/api/auction")
+  ).json()) as { totalViews: number | null };
+
+describe("durable historic page views", () => {
+  it("hides an unknown total and does not let page requests trigger analytics queries", async () => {
+    expect((await snapshot()).totalViews).toBeNull();
+    expect(requests).toBe(0);
+    expect(
+      (
+        await mf.dispatchFetch("https://thedrivingfly.com/api/syncPageViews", {
+          method: "POST",
+          headers: { Origin: "https://thedrivingfly.com" },
+        })
+      ).status,
+    ).toBe(404);
+    expect(requests).toBe(0);
+  });
+  it("backfills, replaces daily counts without double counting, and retains older history", async () => {
+    // Start within the refresh window, with an older archived daily aggregate.
+    await stub.testSql("INSERT INTO page_views VALUES ('2026-09-08', 100)");
+    await stub.testSql(
+      "INSERT INTO counters VALUES ('views_synced_through', ?)",
+      Date.now(),
+    );
+    await stub.syncPageViews();
+    expect((await snapshot()).totalViews).toBe(112);
+    await stub.syncPageViews();
+    expect((await snapshot()).totalViews).toBe(112);
+    count = 17;
+    await stub.syncPageViews();
+    expect((await snapshot()).totalViews).toBe(117);
+  });
+  it("preserves the last good total and sync position on GraphQL or malformed-data failures", async () => {
+    const before = await stub.testSql(
+      "SELECT * FROM counters WHERE name = 'views_synced_through'",
+    );
+    fail = true;
+    await expect(stub.syncPageViews()).rejects.toThrow();
+    expect((await snapshot()).totalViews).toBe(117);
+    expect(
+      await stub.testSql(
+        "SELECT * FROM counters WHERE name = 'views_synced_through'",
+      ),
+    ).toEqual(before);
+    fail = false;
+    invalid = true;
+    await expect(stub.syncPageViews()).rejects.toThrow();
+    expect((await snapshot()).totalViews).toBe(117);
+    invalid = false;
+    count = 20;
+    await stub.syncPageViews();
+    expect((await snapshot()).totalViews).toBe(120);
+  });
+});

--- a/apps/website/worker/auction.ts
+++ b/apps/website/worker/auction.ts
@@ -215,7 +215,7 @@ export class Auction extends DurableObject<Env> {
           : "unavailable",
     };
   }
-  // Only called through the Worker binding by the hourly cron, never a public HTTP route.
+  // Only called through the Worker binding by the five-minute cron, never a public HTTP route.
   async syncPageViews() {
     if (this.env.SITE_URL !== "https://thedrivingfly.com") return;
     if (!this.env.CLOUDFLARE_ANALYTICS_TOKEN)

--- a/apps/website/worker/auction.ts
+++ b/apps/website/worker/auction.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import Stripe from "stripe";
+import { ANALYTICS_START, fetchPageViews } from "./page-views";
 import { z } from "zod";
 import { decode, encode } from "fast-png";
 import {
@@ -39,6 +40,7 @@ const DAY = 86_400_000;
 
 export class Auction extends DurableObject<Env> {
   private sql: SqlStorage;
+  private viewsWork: Promise<void> | undefined;
   private notificationWork: Promise<void> | undefined;
   private refundWork: Promise<void> | undefined;
   private wraps: CustomWrapOrders;
@@ -61,6 +63,7 @@ export class Auction extends DurableObject<Env> {
       );
       CREATE INDEX IF NOT EXISTS credit_bid ON complimentary_credits(bid_id);
       CREATE TABLE IF NOT EXISTS uploads (token TEXT PRIMARY KEY, created_at INTEGER NOT NULL, bid_id TEXT);
+      CREATE TABLE IF NOT EXISTS page_views (day TEXT PRIMARY KEY, views INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
       INSERT OR IGNORE INTO counters VALUES ('revision', 0);
       CREATE TABLE IF NOT EXISTS limits (key TEXT PRIMARY KEY, count INTEGER NOT NULL, expires_at INTEGER NOT NULL);
@@ -196,6 +199,12 @@ export class Auction extends DurableObject<Env> {
       totalRaised: totals.total + customWrap.totalRaised,
       totalPurchases: totals.count + customWrap.soldCount,
       online: this.ctx.getWebSockets().length,
+      totalViews:
+        this.sql
+          .exec<{ value: number }>(
+            "SELECT value FROM counters WHERE name = 'total_views'",
+          )
+          .toArray()[0]?.value ?? null,
       paymentsEnabled: Boolean(
         this.env.STRIPE_API_KEY && this.env.STRIPE_WEBHOOK_SECRET,
       ),
@@ -205,6 +214,60 @@ export class Auction extends DurableObject<Env> {
           ? "live"
           : "unavailable",
     };
+  }
+  // Only called through the Worker binding by the hourly cron, never a public HTTP route.
+  async syncPageViews() {
+    if (this.env.SITE_URL !== "https://thedrivingfly.com") return;
+    if (!this.env.CLOUDFLARE_ANALYTICS_TOKEN)
+      throw new Error("Missing Web Analytics token");
+    if (!this.viewsWork) {
+      this.viewsWork = this.updatePageViews().finally(() => {
+        this.viewsWork = undefined;
+      });
+    }
+    return this.viewsWork;
+  }
+  private async updatePageViews() {
+    const now = Date.now();
+    const through =
+      this.sql
+        .exec<{ value: number }>(
+          "SELECT value FROM counters WHERE name = 'views_synced_through'",
+        )
+        .toArray()[0]?.value ?? ANALYTICS_START;
+    // Re-query two completed UTC days for delayed beacons. Older daily totals stay durable.
+    let from = Math.max(
+      ANALYTICS_START,
+      Math.floor(through / DAY) * DAY - 2 * DAY,
+    );
+    // Bounded catch-up, without skipping missing history after an outage.
+    for (let batch = 0; batch < 4 && from < now; batch++) {
+      const to = Math.min(from + 7 * DAY, now);
+      const days = await fetchPageViews(
+        this.env.CLOUDFLARE_ANALYTICS_TOKEN!,
+        from,
+        to,
+      );
+      this.ctx.storage.transactionSync(() => {
+        for (const [day, views] of days)
+          this.sql.exec(
+            "INSERT INTO page_views VALUES (?, ?) ON CONFLICT(day) DO UPDATE SET views = excluded.views",
+            day,
+            views,
+          );
+        this.sql.exec(
+          "INSERT OR REPLACE INTO counters VALUES ('views_synced_through', ?)",
+          to,
+        );
+        // Never publish an incomplete backfill or replace a good total with a failed query.
+        if (to === now)
+          this.sql.exec(
+            "INSERT OR REPLACE INTO counters SELECT 'total_views', COALESCE(SUM(views), 0) FROM page_views",
+          );
+      });
+      from = to;
+    }
+    this.broadcast();
   }
   private broadcast() {
     const message = JSON.stringify(this.snapshot());

--- a/apps/website/worker/env.ts
+++ b/apps/website/worker/env.ts
@@ -1,7 +1,8 @@
-export interface Env extends Pick<
-  CloudflareBindings,
-  "AUCTION" | "ARTWORK" | "ASSETS" | "SITE_URL"
-> {
+import type { Auction } from "./auction";
+
+export interface Env extends Pick<CloudflareBindings, "ARTWORK" | "ASSETS" | "SITE_URL"> {
+  AUCTION: DurableObjectNamespace<Auction>;
+  CLOUDFLARE_ANALYTICS_TOKEN?: string;
   EMAIL?: SendEmail;
   OUTBID_EMAIL_FROM?: string;
   /** Required for test-mode Stripe: all test mail is redirected here. */

--- a/apps/website/worker/index.ts
+++ b/apps/website/worker/index.ts
@@ -5,6 +5,11 @@ import type { Env } from "./env";
 export { Auction } from "./auction";
 
 export default {
+  async scheduled(_event: ScheduledController, env: Env) {
+    await env.AUCTION.get(
+      env.AUCTION.idFromName("the-driving-fly-v1"),
+    ).syncPageViews();
+  },
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const url = new URL(request.url);
     if (url.hostname === "www.thedrivingfly.com") {

--- a/apps/website/worker/page-views.ts
+++ b/apps/website/worker/page-views.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+export const ANALYTICS_START = Date.parse("2026-09-09T00:00:00Z");
+export const DAY = 86_400_000;
+const responseSchema = z.object({
+  errors: z.array(z.unknown()).nullish(),
+  data: z
+    .object({
+      viewer: z.object({
+        accounts: z
+          .array(
+            z.object({
+              rumPageloadEventsAdaptiveGroups: z.array(
+                z.object({
+                  count: z.number().int().nonnegative().safe(),
+                  dimensions: z.object({ date: z.iso.date() }),
+                }),
+              ),
+            }),
+          )
+          .length(1),
+      }),
+    })
+    .nullable(),
+});
+
+// Cloudflare's count is already sampling-adjusted. Do not multiply it by sampleInterval.
+export async function fetchPageViews(token: string, from: number, to: number) {
+  const response = await fetch("https://api.cloudflare.com/client/v4/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    signal: AbortSignal.timeout(20_000),
+    body: JSON.stringify({
+      query: `query PageViews($from: Time!, $to: Time!) {
+        viewer { accounts(filter: {accountTag: "94f9d97fe2538adb3efe55c05b63637d"}) {
+          rumPageloadEventsAdaptiveGroups(limit: 8, filter: {
+            datetime_geq: $from, datetime_lt: $to,
+            siteTag: "a9425d0f08934c0b919b4c5ff11fb5f7", bot: 0
+          }) { count dimensions { date } }
+        } }
+      }`,
+      variables: {
+        from: new Date(from).toISOString(),
+        to: new Date(to).toISOString(),
+      },
+    }),
+  });
+  if (!response.ok) throw new Error(`Web Analytics HTTP ${response.status}`);
+  const result = responseSchema.parse(await response.json());
+  if (result.errors?.length || !result.data)
+    throw new Error("Web Analytics query failed");
+  const days = new Map<string, number>();
+  for (let day = from; day < to; day += DAY) {
+    days.set(new Date(day).toISOString().slice(0, 10), 0);
+  }
+  for (const row of result.data.viewer.accounts[0]
+    .rumPageloadEventsAdaptiveGroups) {
+    if (!days.has(row.dimensions.date))
+      throw new Error("Unexpected analytics date");
+    days.set(row.dimensions.date, row.count);
+  }
+  return days;
+}

--- a/apps/website/wrangler.jsonc
+++ b/apps/website/wrangler.jsonc
@@ -16,7 +16,7 @@
     "binding": "ASSETS",
     "run_worker_first": ["/api/*"],
   },
-  "triggers": { "crons": ["7 * * * *"] },
+  "triggers": { "crons": ["*/5 * * * *"] },
   "observability": { "enabled": true },
   "vars": {
     "SITE_URL": "https://thedrivingfly.com",

--- a/apps/website/wrangler.jsonc
+++ b/apps/website/wrangler.jsonc
@@ -16,6 +16,7 @@
     "binding": "ASSETS",
     "run_worker_first": ["/api/*"],
   },
+  "triggers": { "crons": ["7 * * * *"] },
   "observability": { "enabled": true },
   "vars": {
     "SITE_URL": "https://thedrivingfly.com",
@@ -41,6 +42,7 @@
       "workers_dev": true,
       "preview_urls": false,
       "routes": [],
+      "triggers": { "crons": [] },
       "vars": {
         "SITE_URL": "https://the-driving-fly-staging.mxunthank.workers.dev",
         "OUTBID_EMAIL_FROM": "updates@notify.thedrivingfly.com",


### PR DESCRIPTION
Adds Cloudflare Web Analytics total page views beside “online now”, with both counts visible on mobile. Backfills from September 9, 2026, when tracking was enabled, and excludes known bots. The exact GraphQL query was verified against the live dashboard (975 page views at the final API check).

A five-minute cron reads analytics through a server-only token and persists daily aggregates in Durable Object SQLite. Refreshes replace overlapping days without double counting; older totals survive analytics retention. Failed queries preserve the last complete total, and the counter stays hidden until initial backfill finishes. Staging cannot run the production sync.

Validation: TypeScript, 49 tests, OpenNext Worker build, and desktop/390px mobile visual checks using an isolated 975-view fixture. Includes tests for unknown totals, preventing public sync triggers, repeated refreshes, retaining older history, and failed/malformed analytics responses.

The dedicated account Analytics Read token is saved as the encrypted runtime secret `CLOUDFLARE_ANALYTICS_TOKEN`; no credential value is in Git or browser code. Reconciled with the latest main, including custom-wrap and purchase-link changes. Release uses Cloudflare Git Builds.
