### PR TITLE
Remove claimed count and link minimum price to spot purchase

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -217,10 +217,25 @@ input[type="checkbox"] {
   font-size: 12px;
   color: var(--muted);
 }
-.stat-denominator {
-  color: #65715e;
-  font-weight: 400;
-  font-size: 19px;
+.entry-bid-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: inherit;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+.entry-bid-link > span {
+  font-size: 12px;
+  color: var(--muted);
+}
+.entry-bid-link strong {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+.entry-bid-link:hover:not(:disabled) strong {
+  color: var(--green);
 }
 .stat-divider {
   width: 1px;
@@ -1843,9 +1858,6 @@ fieldset {
   }
   .hero-stats > div > span {
     font-size: 12px;
-  }
-  .stat-denominator {
-    font-size: 15px;
   }
   .hero-stats > div {
     gap: 5px;

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -89,6 +89,9 @@ export default function AuctionSite() {
   const entryBid = Math.min(
     ...slots.map((slot) => minimumBid(snapshot.placements[slot.id]?.amount)),
   );
+  const entrySlot = slots.find(
+    (slot) => minimumBid(snapshot.placements[slot.id]?.amount) === entryBid,
+  );
   const filtered = useMemo(
     () =>
       slots
@@ -240,16 +243,16 @@ export default function AuctionSite() {
             </div>
             <span className="stat-divider" />
             <div>
-              <strong>
-                {loaded ? taken : "—"}
-                <span className="stat-denominator"> / {slots.length}</span>
-              </strong>
-              <span>spots claimed</span>
-            </div>
-            <span className="stat-divider" />
-            <div>
-              <strong>{loaded ? money(entryBid) : "—"}</strong>
-              <span>current minimum to get on the car</span>
+              <button
+                type="button"
+                className="entry-bid-link"
+                disabled={!loaded || !entrySlot}
+                aria-haspopup="dialog"
+                onClick={() => entrySlot && choose(entrySlot.id)}
+              >
+                <strong>{loaded ? money(entryBid) : "—"}</strong>
+                <span>current minimum to get on the car</span>
+              </button>
             </div>
             <span className="stat-divider" />
             <div className="highest-bid-stat">


### PR DESCRIPTION
Remove the claimed-spots count from the hero rail and make the minimum sponsorship price open the purchase dialog for a spot at that price. The price and caption are one keyboard-accessible control, with an underlined price and a disabled state until auction data loads.

Validation: `npm run check` passed (TypeScript, all 46 tests, and the OpenNext Worker build); `git diff --check` passed. Based on the latest `origin/main`. No production deployment performed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the claimed-spots count from the hero rail and makes the minimum sponsorship price open the purchase dialog for that spot. The price and caption are now a single keyboard-accessible button with an underlined price, disabled until auction data loads.

<sup>Written for commit 065ac62aade4d858eec0258b9e406bcc35297164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

