### PR TITLE
Fix blank purchase model caused by hidden dialog initialization

### DIFF
--- a/apps/website/src/components/car-viewer.tsx
+++ b/apps/website/src/components/car-viewer.tsx
@@ -8,6 +8,7 @@ import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 import { Maximize2, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import { artworkBounds } from "@/lib/artwork-bounds.mjs";
+import { resizeViewer } from "@/lib/viewer-size";
 import styles from "./car-ad-preview.module.css";
 import {
   artworkCrops,
@@ -305,10 +306,7 @@ export default function CarViewer({
     );
     const resize = () => {
       const { width, height } = element.getBoundingClientRect();
-      renderer.setSize(width, height);
-      camera.aspect = width / height;
-      camera.fov = width < 600 ? 45 : 34;
-      camera.updateProjectionMatrix();
+      if (!resizeViewer(camera, renderer, width, height)) return;
       frameCamera(state, framing.current.view, framing.current.focus);
     };
     const observer = new ResizeObserver(resize);

--- a/apps/website/src/lib/viewer-size.ts
+++ b/apps/website/src/lib/viewer-size.ts
@@ -1,0 +1,23 @@
+import type { PerspectiveCamera } from "three";
+
+export function resizeViewer(
+  camera: PerspectiveCamera,
+  renderer: { setSize(width: number, height: number): void },
+  width: number,
+  height: number,
+): boolean {
+  // A child effect can run before its parent opens the native dialog.
+  // Never let a hidden layout poison the camera with NaN or Infinity.
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  )
+    return false;
+  renderer.setSize(width, height);
+  camera.aspect = width / height;
+  camera.fov = width < 600 ? 45 : 34;
+  camera.updateProjectionMatrix();
+  return true;
+}

--- a/apps/website/tests/viewer-size.test.ts
+++ b/apps/website/tests/viewer-size.test.ts
@@ -1,0 +1,43 @@
+import { PerspectiveCamera, Vector3 } from "three";
+import { expect, it, vi } from "vitest";
+import { resizeViewer } from "../src/lib/viewer-size";
+
+it("keeps a hidden dialog camera finite until it opens, including repeated opens", () => {
+  const camera = new PerspectiveCamera(34, 1, 0.1, 100);
+  const renderer = { setSize: vi.fn() };
+  for (const [width, height] of [
+    [0, 0],
+    [390, 220],
+    [0, 0],
+    [800, 500],
+  ]) {
+    const previousAspect = camera.aspect;
+    const visible = resizeViewer(camera, renderer, width, height);
+    expect(visible).toBe(width > 0 && height > 0);
+    expect(camera.aspect).toBe(visible ? width / height : previousAspect);
+    expect(camera.projectionMatrix.elements.every(Number.isFinite)).toBe(true);
+    // Exercise the same aspect-dependent framing that used to propagate NaN.
+    const destination = new Vector3(3.3, 2.65, -4.4).multiplyScalar(
+      Math.max(1, 1.05 / camera.aspect),
+    );
+    camera.position.lerp(destination, 0.09);
+    expect(camera.position.toArray().every(Number.isFinite)).toBe(true);
+  }
+  expect(renderer.setSize.mock.calls).toEqual([
+    [390, 220],
+    [800, 500],
+  ]);
+});
+
+it.each([
+  [0, 200],
+  [200, 0],
+  [NaN, 200],
+  [200, Infinity],
+])("ignores invalid viewport %s by %s", (width, height) => {
+  const camera = new PerspectiveCamera();
+  const renderer = { setSize: vi.fn() };
+  expect(resizeViewer(camera, renderer, width, height)).toBe(false);
+  expect(renderer.setSize).not.toHaveBeenCalled();
+  expect(camera.projectionMatrix.elements.every(Number.isFinite)).toBe(true);
+});


### PR DESCRIPTION
The purchase viewer can mount before its parent effect calls `dialog.showModal()`. Its initial bounds are then 0 × 0; dividing them produces a NaN camera aspect, and the synchronous render propagates NaN into the camera position. A later ResizeObserver update cannot recover that position. This is a concrete timing-dependent failure consistent with some visitors seeing a blank purchase model; the reported visitor's session has not been reproduced.

Skip resizing and reframing for zero or non-finite bounds, retaining the valid initial camera until the dialog has a visible size. Add regression coverage using a real Three.js camera through hidden/open/reopen transitions and invalid dimensions.

Validation: TypeScript passed, all 51 tests passed, and the OpenNext Cloudflare Worker build passed. Live model and Draco WASM endpoints returned HTTP 200. No production deployment was performed; affected-device visual verification remains outstanding.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the purchase viewer rendering a blank model when it mounts before the dialog opens. The resize handler now skips zero or non-finite viewport bounds, keeping the valid initial camera until the dialog has a visible size.

**Bug Fixes**
- Moved resize logic into a shared `resizeViewer` helper in `src/lib/viewer-size.ts`.
- Added regression tests covering hidden/open/reopen transitions and invalid dimensions.

All 51 tests pass and the OpenNext Cloudflare Worker build succeeds. No production deployment was performed; visual verification on affected devices is still outstanding.

<sup>Written for commit 60cb2a52ef5db3ca7e512c88d7feff1094b3eabb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

