### PR TITLE
Show total HTTP requests instead of page views

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -124,28 +124,28 @@ Browser-only auction fixtures verified the default camera on all five faces, the
 
 Vehicle attribution is retained at `/credits`; font licensing is included with the model. All fonts, model textures, and Draco decoders used by the site are self-hosted.
 
-## Historic page-view counter
+## Historic request counter
 
-The hero displays Cloudflare Web Analytics page views next to the active browser
-connection count. This is page views (including repeat views), not unique people.
-The source is site `a9425d0f08934c0b919b4c5ff11fb5f7`, with known bots excluded,
-starting September 9, 2026 UTC, the date tracking was enabled. The GraphQL `count`
-is already sampling-adjusted, so it is not multiplied by the sampling interval.
+The hero displays Cloudflare zone HTTP request totals next to the active browser
+connection count. Requests include page loads, assets, API polling, repeat requests,
+and bot traffic. The label is “total requests”, not views or unique visitors.
+The source is the site's zone HTTP analytics, starting September 9, 2026 UTC,
+when the domain was added to Cloudflare. Use `httpRequests1dGroups.sum.requests`.
 
-Before merging this feature, store a dedicated Cloudflare token with account
-Analytics Read access as the production Worker secret `CLOUDFLARE_ANALYTICS_TOKEN`.
-Do not use an expiring Wrangler login token. Keep the PR in draft until this is
-configured. Secret configuration does not authorize manually deploying Worker code.
+The encrypted production Worker secret `CLOUDFLARE_ANALYTICS_TOKEN` needs Zone
+Analytics Read permission for this zone. It must never be committed or sent to
+browsers. The previous Web Analytics account-only permission must be replaced
+before releasing this change. Keep the PR in draft until credentials are configured.
 
-Cloudflare cron runs every five minutes. It calls the auction object through its
-private Worker binding; visitors cannot trigger a sync. Daily aggregates persist
-in Durable Object SQLite. The current day and previous two days are replaced on
-refresh to incorporate delayed data without double counting. Older days remain
-stored after Cloudflare retention expires. A bounded catch-up processes up to four
-seven-day batches per run; failures preserve the last successfully published total.
-The counter stays hidden until the first complete backfill. Staging has no cron and
-cannot sync production analytics. After the Git build deploys, verify the first cron
-succeeds and `/api/auction` reports `totalViews` matching the stored daily sum.
+Cloudflare cron runs every five minutes and invokes the auction object through
+its private Worker binding. Daily aggregates persist in Durable Object SQLite;
+refreshes replace the current and previous two days without double counting.
+Older totals survive analytics retention. Catch-up is bounded to four seven-day
+batches per run, preserving the last complete total on failure. The new counter
+uses separate storage from the previous page-view metric; it never adds page
+views to requests. It stays hidden until the first complete backfill. Staging
+cannot sync production analytics.
 
-Cloudflare figures can be sampled and omit blocked/missed beacons. They represent
-recorded views since tracking began, not a guaranteed census of every visitor.
+After the Git-based release, verify the first successful cron and check
+`/api/auction.totalRequests` against Cloudflare's zone request totals. Analytics
+processing and the five-minute schedule mean this is not a per-request live ticker.

--- a/apps/website/src/app/privacy/page.tsx
+++ b/apps/website/src/app/privacy/page.tsx
@@ -55,9 +55,10 @@ export default function Privacy() {
         them after two minutes. Hosting providers may retain operational logs
         under their own policies. The online counter counts active browser
         connections, not identifiable people. Cloudflare Web Analytics measures
-        page views without analytics cookies. We retain daily aggregate view
-        counts to display the historic total, excluding known bots. We do not
-        add advertising trackers or analytics cookies.
+        page views without analytics cookies. We retain daily aggregate HTTP
+        request counts to display the historic total, including requests for
+        pages, assets, and APIs, and traffic from bots. We do not add
+        advertising trackers or analytics cookies.
       </p>
       <h2>Retention and requests</h2>
       <p>

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -227,11 +227,11 @@ export default function AuctionSite() {
                   ? `${snapshot.online} online now`
                   : `${slots.length} spots. One tiny driver.`}
               </span>
-              {snapshot.totalViews != null && (
+              {snapshot.totalRequests != null && (
                 <>
                   <span aria-hidden="true">·</span>
-                  <span title="Page views recorded by Cloudflare Web Analytics since tracking began; known bots excluded. Updated every five minutes.">
-                    {snapshot.totalViews.toLocaleString("en-US")} total views
+                  <span title="HTTP requests recorded by Cloudflare since launch, including pages, assets, API calls, and bots. Updated every five minutes.">
+                    {snapshot.totalRequests.toLocaleString("en-US")} total requests
                   </span>
                 </>
               )}

--- a/apps/website/src/lib/auction.ts
+++ b/apps/website/src/lib/auction.ts
@@ -63,7 +63,7 @@ export type AuctionSnapshot = {
   totalRaised: number;
   totalPurchases: number;
   online: number;
-  totalViews: number | null;
+  totalRequests: number | null;
   paymentsEnabled: boolean;
   paymentMode: "live" | "test" | "unavailable";
 };
@@ -77,7 +77,7 @@ export const emptySnapshot: AuctionSnapshot = {
   totalRaised: 0,
   totalPurchases: 0,
   online: 0,
-  totalViews: null,
+  totalRequests: null,
   paymentsEnabled: false,
   paymentMode: "unavailable",
 };

--- a/apps/website/tests/request-counts.test.ts
+++ b/apps/website/tests/request-counts.test.ts
@@ -12,7 +12,7 @@ let fail = false;
 let invalid = false;
 let requests = 0;
 let stub: {
-  syncPageViews(): Promise<void>;
+  syncRequestCounts(): Promise<void>;
   testSql(
     query: string,
     ...values: (string | number | null)[]
@@ -20,7 +20,7 @@ let stub: {
 };
 
 beforeAll(async () => {
-  directory = await mkdtemp(join(tmpdir(), "fly-views-"));
+  directory = await mkdtemp(join(tmpdir(), "fly-requests-"));
   const script = join(directory, "worker.mjs");
   await build({
     entryPoints: ["tests/fixtures/auction-worker.ts"],
@@ -51,8 +51,11 @@ beforeAll(async () => {
         query: string;
         variables: { from: string; to: string };
       };
-      expect(body.query).toContain("bot: 0");
-      expect(body.query).toContain("a9425d0f08934c0b919b4c5ff11fb5f7");
+      expect(body.query).not.toContain("bot:");
+      expect(body.query).toContain("sum { requests }");
+      expect(body.variables.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(body.variables.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(body.query).toContain("0f870574c4a4f0ee249260cb93e3bff6");
       if (fail)
         return Response.json({
           errors: [{ message: "Permission denied" }],
@@ -62,11 +65,11 @@ beforeAll(async () => {
         errors: null,
         data: {
           viewer: {
-            accounts: [
+            zones: [
               {
-                rumPageloadEventsAdaptiveGroups: [
+                httpRequests1dGroups: [
                   {
-                    count: invalid ? -1 : count,
+                    sum: { requests: invalid ? -1 : count },
                     dimensions: { date: body.variables.from.slice(0, 10) },
                   },
                 ],
@@ -87,56 +90,65 @@ afterAll(async () => {
 const snapshot = async () =>
   (await (
     await mf.dispatchFetch("https://thedrivingfly.com/api/auction")
-  ).json()) as { totalViews: number | null };
+  ).json()) as { totalRequests: number | null };
 
-describe("durable historic page views", () => {
+describe("durable historic request counts", () => {
   it("hides an unknown total and does not let page requests trigger analytics queries", async () => {
-    expect((await snapshot()).totalViews).toBeNull();
+    // Existing production page-view data must not seed the new request metric.
+    await stub.testSql("INSERT INTO counters VALUES ('total_views', 990)");
+    await stub.testSql(
+      "INSERT INTO counters VALUES ('views_synced_through', ?)",
+      Date.now(),
+    );
+    expect((await snapshot()).totalRequests).toBeNull();
     expect(requests).toBe(0);
     expect(
       (
-        await mf.dispatchFetch("https://thedrivingfly.com/api/syncPageViews", {
-          method: "POST",
-          headers: { Origin: "https://thedrivingfly.com" },
-        })
+        await mf.dispatchFetch(
+          "https://thedrivingfly.com/api/syncRequestCounts",
+          {
+            method: "POST",
+            headers: { Origin: "https://thedrivingfly.com" },
+          },
+        )
       ).status,
     ).toBe(404);
     expect(requests).toBe(0);
   });
   it("backfills, replaces daily counts without double counting, and retains older history", async () => {
     // Start within the refresh window, with an older archived daily aggregate.
-    await stub.testSql("INSERT INTO page_views VALUES ('2026-09-08', 100)");
+    await stub.testSql("INSERT INTO request_counts VALUES ('2026-09-08', 100)");
     await stub.testSql(
-      "INSERT INTO counters VALUES ('views_synced_through', ?)",
+      "INSERT INTO counters VALUES ('requests_synced_through', ?)",
       Date.now(),
     );
-    await stub.syncPageViews();
-    expect((await snapshot()).totalViews).toBe(112);
-    await stub.syncPageViews();
-    expect((await snapshot()).totalViews).toBe(112);
+    await stub.syncRequestCounts();
+    expect((await snapshot()).totalRequests).toBe(112);
+    await stub.syncRequestCounts();
+    expect((await snapshot()).totalRequests).toBe(112);
     count = 17;
-    await stub.syncPageViews();
-    expect((await snapshot()).totalViews).toBe(117);
+    await stub.syncRequestCounts();
+    expect((await snapshot()).totalRequests).toBe(117);
   });
   it("preserves the last good total and sync position on GraphQL or malformed-data failures", async () => {
     const before = await stub.testSql(
-      "SELECT * FROM counters WHERE name = 'views_synced_through'",
+      "SELECT * FROM counters WHERE name = 'requests_synced_through'",
     );
     fail = true;
-    await expect(stub.syncPageViews()).rejects.toThrow();
-    expect((await snapshot()).totalViews).toBe(117);
+    await expect(stub.syncRequestCounts()).rejects.toThrow();
+    expect((await snapshot()).totalRequests).toBe(117);
     expect(
       await stub.testSql(
-        "SELECT * FROM counters WHERE name = 'views_synced_through'",
+        "SELECT * FROM counters WHERE name = 'requests_synced_through'",
       ),
     ).toEqual(before);
     fail = false;
     invalid = true;
-    await expect(stub.syncPageViews()).rejects.toThrow();
-    expect((await snapshot()).totalViews).toBe(117);
+    await expect(stub.syncRequestCounts()).rejects.toThrow();
+    expect((await snapshot()).totalRequests).toBe(117);
     invalid = false;
     count = 20;
-    await stub.syncPageViews();
-    expect((await snapshot()).totalViews).toBe(120);
+    await stub.syncRequestCounts();
+    expect((await snapshot()).totalRequests).toBe(120);
   });
 });

--- a/apps/website/worker/auction.ts
+++ b/apps/website/worker/auction.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import Stripe from "stripe";
-import { ANALYTICS_START, fetchPageViews } from "./page-views";
+import { ANALYTICS_START, fetchRequestCounts } from "./request-counts";
 import { z } from "zod";
 import { decode, encode } from "fast-png";
 import {
@@ -40,7 +40,7 @@ const DAY = 86_400_000;
 
 export class Auction extends DurableObject<Env> {
   private sql: SqlStorage;
-  private viewsWork: Promise<void> | undefined;
+  private requestsWork: Promise<void> | undefined;
   private notificationWork: Promise<void> | undefined;
   private refundWork: Promise<void> | undefined;
   private wraps: CustomWrapOrders;
@@ -63,7 +63,7 @@ export class Auction extends DurableObject<Env> {
       );
       CREATE INDEX IF NOT EXISTS credit_bid ON complimentary_credits(bid_id);
       CREATE TABLE IF NOT EXISTS uploads (token TEXT PRIMARY KEY, created_at INTEGER NOT NULL, bid_id TEXT);
-      CREATE TABLE IF NOT EXISTS page_views (day TEXT PRIMARY KEY, views INTEGER NOT NULL);
+      CREATE TABLE IF NOT EXISTS request_counts (day TEXT PRIMARY KEY, requests INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
       INSERT OR IGNORE INTO counters VALUES ('revision', 0);
       CREATE TABLE IF NOT EXISTS limits (key TEXT PRIMARY KEY, count INTEGER NOT NULL, expires_at INTEGER NOT NULL);
@@ -199,10 +199,10 @@ export class Auction extends DurableObject<Env> {
       totalRaised: totals.total + customWrap.totalRaised,
       totalPurchases: totals.count + customWrap.soldCount,
       online: this.ctx.getWebSockets().length,
-      totalViews:
+      totalRequests:
         this.sql
           .exec<{ value: number }>(
-            "SELECT value FROM counters WHERE name = 'total_views'",
+            "SELECT value FROM counters WHERE name = 'total_requests'",
           )
           .toArray()[0]?.value ?? null,
       paymentsEnabled: Boolean(
@@ -216,26 +216,26 @@ export class Auction extends DurableObject<Env> {
     };
   }
   // Only called through the Worker binding by the five-minute cron, never a public HTTP route.
-  async syncPageViews() {
+  async syncRequestCounts() {
     if (this.env.SITE_URL !== "https://thedrivingfly.com") return;
     if (!this.env.CLOUDFLARE_ANALYTICS_TOKEN)
-      throw new Error("Missing Web Analytics token");
-    if (!this.viewsWork) {
-      this.viewsWork = this.updatePageViews().finally(() => {
-        this.viewsWork = undefined;
+      throw new Error("Missing analytics token");
+    if (!this.requestsWork) {
+      this.requestsWork = this.updateRequestCounts().finally(() => {
+        this.requestsWork = undefined;
       });
     }
-    return this.viewsWork;
+    return this.requestsWork;
   }
-  private async updatePageViews() {
+  private async updateRequestCounts() {
     const now = Date.now();
     const through =
       this.sql
         .exec<{ value: number }>(
-          "SELECT value FROM counters WHERE name = 'views_synced_through'",
+          "SELECT value FROM counters WHERE name = 'requests_synced_through'",
         )
         .toArray()[0]?.value ?? ANALYTICS_START;
-    // Re-query two completed UTC days for delayed beacons. Older daily totals stay durable.
+    // Re-query two completed UTC days for delayed analytics. Older daily totals stay durable.
     let from = Math.max(
       ANALYTICS_START,
       Math.floor(through / DAY) * DAY - 2 * DAY,
@@ -243,26 +243,26 @@ export class Auction extends DurableObject<Env> {
     // Bounded catch-up, without skipping missing history after an outage.
     for (let batch = 0; batch < 4 && from < now; batch++) {
       const to = Math.min(from + 7 * DAY, now);
-      const days = await fetchPageViews(
+      const days = await fetchRequestCounts(
         this.env.CLOUDFLARE_ANALYTICS_TOKEN!,
         from,
         to,
       );
       this.ctx.storage.transactionSync(() => {
-        for (const [day, views] of days)
+        for (const [day, requests] of days)
           this.sql.exec(
-            "INSERT INTO page_views VALUES (?, ?) ON CONFLICT(day) DO UPDATE SET views = excluded.views",
+            "INSERT INTO request_counts VALUES (?, ?) ON CONFLICT(day) DO UPDATE SET requests = excluded.requests",
             day,
-            views,
+            requests,
           );
         this.sql.exec(
-          "INSERT OR REPLACE INTO counters VALUES ('views_synced_through', ?)",
+          "INSERT OR REPLACE INTO counters VALUES ('requests_synced_through', ?)",
           to,
         );
         // Never publish an incomplete backfill or replace a good total with a failed query.
         if (to === now)
           this.sql.exec(
-            "INSERT OR REPLACE INTO counters SELECT 'total_views', COALESCE(SUM(views), 0) FROM page_views",
+            "INSERT OR REPLACE INTO counters SELECT 'total_requests', COALESCE(SUM(requests), 0) FROM request_counts",
           );
       });
       from = to;

--- a/apps/website/worker/index.ts
+++ b/apps/website/worker/index.ts
@@ -8,7 +8,7 @@ export default {
   async scheduled(_event: ScheduledController, env: Env) {
     await env.AUCTION.get(
       env.AUCTION.idFromName("the-driving-fly-v1"),
-    ).syncPageViews();
+    ).syncRequestCounts();
   },
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const url = new URL(request.url);

--- a/apps/website/worker/request-counts.ts
+++ b/apps/website/worker/request-counts.ts
@@ -7,12 +7,14 @@ const responseSchema = z.object({
   data: z
     .object({
       viewer: z.object({
-        accounts: z
+        zones: z
           .array(
             z.object({
-              rumPageloadEventsAdaptiveGroups: z.array(
+              httpRequests1dGroups: z.array(
                 z.object({
-                  count: z.number().int().nonnegative().safe(),
+                  sum: z.object({
+                    requests: z.number().int().nonnegative().safe(),
+                  }),
                   dimensions: z.object({ date: z.iso.date() }),
                 }),
               ),
@@ -24,8 +26,12 @@ const responseSchema = z.object({
     .nullable(),
 });
 
-// Cloudflare's count is already sampling-adjusted. Do not multiply it by sampleInterval.
-export async function fetchPageViews(token: string, from: number, to: number) {
+// Zone HTTP totals include repeat requests, assets, API calls and bots.
+export async function fetchRequestCounts(
+  token: string,
+  from: number,
+  to: number,
+) {
   const response = await fetch("https://api.cloudflare.com/client/v4/graphql", {
     method: "POST",
     headers: {
@@ -34,33 +40,32 @@ export async function fetchPageViews(token: string, from: number, to: number) {
     },
     signal: AbortSignal.timeout(20_000),
     body: JSON.stringify({
-      query: `query PageViews($from: Time!, $to: Time!) {
-        viewer { accounts(filter: {accountTag: "94f9d97fe2538adb3efe55c05b63637d"}) {
-          rumPageloadEventsAdaptiveGroups(limit: 8, filter: {
-            datetime_geq: $from, datetime_lt: $to,
-            siteTag: "a9425d0f08934c0b919b4c5ff11fb5f7", bot: 0
-          }) { count dimensions { date } }
+      query: `query Requests($from: Date!, $to: Date!) {
+        viewer { zones(filter: {zoneTag: "0f870574c4a4f0ee249260cb93e3bff6"}) {
+          httpRequests1dGroups(limit: 8, filter: {
+            date_geq: $from, date_lt: $to
+          }) { sum { requests } dimensions { date } }
         } }
       }`,
       variables: {
-        from: new Date(from).toISOString(),
-        to: new Date(to).toISOString(),
+        from: new Date(from).toISOString().slice(0, 10),
+        to: new Date(Math.ceil(to / DAY) * DAY).toISOString().slice(0, 10),
       },
     }),
   });
-  if (!response.ok) throw new Error(`Web Analytics HTTP ${response.status}`);
+  if (!response.ok)
+    throw new Error(`Request analytics HTTP ${response.status}`);
   const result = responseSchema.parse(await response.json());
   if (result.errors?.length || !result.data)
-    throw new Error("Web Analytics query failed");
+    throw new Error("Request analytics query failed");
   const days = new Map<string, number>();
   for (let day = from; day < to; day += DAY) {
     days.set(new Date(day).toISOString().slice(0, 10), 0);
   }
-  for (const row of result.data.viewer.accounts[0]
-    .rumPageloadEventsAdaptiveGroups) {
+  for (const row of result.data.viewer.zones[0].httpRequests1dGroups) {
     if (!days.has(row.dimensions.date))
       throw new Error("Unexpected analytics date");
-    days.set(row.dimensions.date, row.count);
+    days.set(row.dimensions.date, row.sum.requests);
   }
   return days;
 }


### PR DESCRIPTION
Replaces the hero's Web Analytics page-view total with Cloudflare's total HTTP request count, labeled “total requests”. Includes page loads, assets, API polling, repeat requests, and bot traffic. It does not claim unique visitors or human page views. The verified live source returned 66,103 requests across September 9–10 at the last check.

Uses zone `httpRequests1dGroups.sum.requests` with UTC date boundaries. Preserves the five-minute schedule and durable daily aggregates, using separate storage and a new `totalRequests` snapshot field so old page views are never mixed into the new total. Updated privacy copy and documentation.

Validation: 54 tests, TypeScript, Worker build, and the exact GraphQL query against Cloudflare. Added checks for old page-view data remaining excluded and for date-only query bounds.

Draft pending a token with Zone Analytics Read access limited to the site's zone. Keep the currently deployed page-view token working until the new release is ready. No production changes in this PR yet.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hero's Web Analytics page-view total with Cloudflare's total HTTP request count, labeled "total requests". The new metric includes page loads, assets, API polling, repeat requests, and bot traffic; it no longer excludes known bots and does not claim unique visitors.

- Pulls daily totals from the zone's `httpRequests1dGroups.sum.requests` with UTC date boundaries.
- Stores counts in a new `request_counts` table and exposes them via a `totalRequests` snapshot field, so old page-view data never mixes in.
- Adds tests that verify old page-view data stays excluded and that query bounds are date-only.

**Migration**
- Replace the `CLOUDFLARE_ANALYTICS_TOKEN` secret with one that has Zone Analytics Read access for the site's zone; keep the currently deployed page-view token working until this release is ready.

<sup>Written for commit e20d671d07931acc559c6ce2cd984ef6fb1b8393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

