### PR TITLE
Send site emails from mark@reallynice.company

### DIFF
--- a/apps/website/CUSTOM-WRAPS.md
+++ b/apps/website/CUSTOM-WRAPS.md
@@ -6,7 +6,7 @@ The package is separate from the spot auction. Buying it does not replace existi
 
 ## Purchase notifications
 
-Production uses `CUSTOM_WRAP_EMAIL_TO=mark@reallynice.company`. Messages come from the existing `OUTBID_EMAIL_FROM` sender through the `EMAIL` binding. The operator alert contains the order number, amount paid, buyer email, brand/project name, deliverables, and a Stripe payment link.
+Production uses `CUSTOM_WRAP_EMAIL_TO=mark@reallynice.company`. Buyer confirmations and operator alerts come from **The Driving Fly <mark@reallynice.company>**, configured through `OUTBID_EMAIL_FROM` and the `EMAIL` binding. Replies reach Mark's existing mailbox. The operator alert contains the order number, amount paid, buyer email, brand/project name, deliverables, and a Stripe payment link. Sender authentication is documented in [OUTBID-NOTIFICATIONS.md](OUTBID-NOTIFICATIONS.md#configuration).
 
 The buyer receives a separate welcome email at their verified Stripe Checkout email. It confirms their payment and two videos, asks them to [book a meeting with Mark ASAP](https://cal.com/mark-unthank/meeting), links the [Mini's paint texture on GitHub](https://github.com/MarkUnthank/flyhard/blob/main/apps/mini-livery/custom-wrap/M_Bodywork_Mini2021_d.png), and encourages them to vibe, sketch, or start designing before the call. Replies go to the operator. Both HTML and plain-text versions contain the links. The texture is extracted unchanged from the original packed Blender asset; the adjacent design guide includes attribution and the editable model.
 

--- a/apps/website/OUTBID-NOTIFICATIONS.md
+++ b/apps/website/OUTBID-NOTIFICATIONS.md
@@ -1,6 +1,6 @@
 # Outbid notifications
 
-Cloudflare Email Service sends a transactional email when a confirmed payment replaces a published ad. The sender is **The Driving Fly <updates@notify.thedrivingfly.com>**. The email identifies the displaced placement, the replacement bid, and the current minimum to bid again. Its `?spot=ad-XX` link opens that spot's model preview and bid form with the latest auction price.
+Cloudflare Email Service sends a transactional email when a confirmed payment replaces a published ad. The sender is **The Driving Fly <mark@reallynice.company>**, so replies reach Mark's existing mailbox. The email identifies the displaced placement, the replacement bid, and the current minimum to bid again. Its `?spot=ad-XX` link opens that spot's model preview and bid form with the latest auction price.
 
 ## Payment and delivery behavior
 
@@ -16,7 +16,9 @@ Cloudflare's send binding does not expose an idempotency key. The durable outbox
 
 ## Configuration
 
-Production and staging have an `EMAIL` send binding restricted to the sender above, plus `OUTBID_EMAIL_FROM` in `wrangler.jsonc`. The sender domain `notify.thedrivingfly.com` is onboarded to Cloudflare Email Service with DKIM, SPF, DMARC and a dedicated `cf-bounce` return path. Its DNS setup does not replace the website's domain records or an existing inbox's MX records. No additional email API key is needed.
+Production and staging have an `EMAIL` send binding restricted to the sender above, plus `OUTBID_EMAIL_FROM` in `wrangler.jsonc`. Local configuration uses the same sender with simulated delivery. Custom-wrap buyer confirmations and operator alerts also use this sender.
+
+The sender domain `reallynice.company` must be enabled in Cloudflare Email Service before releasing this configuration. Cloudflare uses `cf-bounce.reallynice.company` for return-path MX and SPF records and `cf-bounce._domainkey.reallynice.company` for DKIM. Keep the existing Google Workspace root MX/SPF and DMARC policy intact. The domain uses strict DMARC alignment, so Cloudflare's DKIM signature must use `d=reallynice.company`; the bounce subdomain's SPF alone does not satisfy strict alignment. No additional email API key is needed. See [Cloudflare's domain configuration guide](https://developers.cloudflare.com/email-service/configuration/domains/).
 
 For Stripe test mode, sending requires a private `OUTBID_EMAIL_TEST_TO` secret. **Every sandbox notification goes to that test address**, with `[TEST]` in the subject and an explanation that no real payment or production replacement occurred. The original bidder email is still used to check ownership, but never used as a sandbox destination. Without the test recipient, queued sandbox mail remains unsent.
 

--- a/apps/website/wrangler.dev.jsonc
+++ b/apps/website/wrangler.dev.jsonc
@@ -6,13 +6,13 @@
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "SITE_URL": "http://localhost:3000",
-    "OUTBID_EMAIL_FROM": "updates@notify.thedrivingfly.com",
+    "OUTBID_EMAIL_FROM": "mark@reallynice.company",
     "CUSTOM_WRAP_EMAIL_TEST_TO": "mark@reallynice.company",
   },
   "send_email": [
     {
       "name": "EMAIL",
-      "allowed_sender_addresses": ["updates@notify.thedrivingfly.com"],
+      "allowed_sender_addresses": ["mark@reallynice.company"],
     },
   ],
   "durable_objects": {

--- a/apps/website/wrangler.jsonc
+++ b/apps/website/wrangler.jsonc
@@ -20,13 +20,13 @@
   "observability": { "enabled": true },
   "vars": {
     "SITE_URL": "https://thedrivingfly.com",
-    "OUTBID_EMAIL_FROM": "updates@notify.thedrivingfly.com",
+    "OUTBID_EMAIL_FROM": "mark@reallynice.company",
     "CUSTOM_WRAP_EMAIL_TO": "mark@reallynice.company",
   },
   "send_email": [
     {
       "name": "EMAIL",
-      "allowed_sender_addresses": ["updates@notify.thedrivingfly.com"],
+      "allowed_sender_addresses": ["mark@reallynice.company"],
     },
   ],
   "durable_objects": {
@@ -45,13 +45,13 @@
       "triggers": { "crons": [] },
       "vars": {
         "SITE_URL": "https://the-driving-fly-staging.mxunthank.workers.dev",
-        "OUTBID_EMAIL_FROM": "updates@notify.thedrivingfly.com",
+        "OUTBID_EMAIL_FROM": "mark@reallynice.company",
         "CUSTOM_WRAP_EMAIL_TEST_TO": "mark@reallynice.company",
       },
       "send_email": [
         {
           "name": "EMAIL",
-          "allowed_sender_addresses": ["updates@notify.thedrivingfly.com"],
+          "allowed_sender_addresses": ["mark@reallynice.company"],
         },
       ],
       "durable_objects": {


### PR DESCRIPTION
Site emails currently use the new `notify.thedrivingfly.com` domain and are being reported in junk. Switch outbid notifications, custom-wrap buyer confirmations, and operator alerts to **The Driving Fly <mark@reallynice.company>**. Update the sender allowlist and sender variable together in production, staging, and local configuration, and document authentication and reply behavior.

Enabled `reallynice.company` in Cloudflare Email Service and verified its sending MX/SPF and DKIM records. Existing Google Workspace root MX/SPF and the strict DMARC policy remain unchanged. Strict DMARC therefore relies on DKIM signing with the exact `reallynice.company` domain. The current production version was matched to the successful Git build for `a6f8037`; this PR is based on that main commit.

Validation: `npm run check` passed (TypeScript, all 54 tests, and the OpenNext Worker build); `git diff --check` passed. No customer emails were sent or resent during validation. Production remains on the existing sender until an authorized merge and Cloudflare Build. Actual inbox placement must be checked after release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches site emails from `updates@notify.thedrivingfly.com` to `mark@reallynice.company` so outbid notifications, custom-wrap buyer confirmations, and operator alerts stop landing in junk. The sender allowlist and `OUTBID_EMAIL_FROM` variable are updated together in production, staging, and local config.

- Docs now describe sender authentication and that replies reach Mark's existing mailbox.
- `reallynice.company` is enabled in Cloudflare Email Service with verified MX/SPF/DKIM; Google Workspace root MX/SPF and strict DMARC are unchanged.
- `npm run check` passed (TypeScript, all 54 tests, OpenNext Worker build) and `git diff --check` passed; no customer emails were sent during validation.

**Migration**
- Production stays on the old sender until merge and a Cloudflare Build; then verify real inbox placement.
- Strict DMARC requires DKIM signing with `d=reallynice.company`; the bounce subdomain's SPF alone won't pass alignment.

<sup>Written for commit b789d08a67da9819e3df9dbb6c205bcd3eccd9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

