### PR TITLE
Hide occupied spots from the auction table

### DIFF
--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -85,6 +85,10 @@ export default function AuctionSite() {
     () => activeSlots(snapshot.placements),
     [snapshot.placements],
   );
+  const openSlots = useMemo(
+    () => slots.filter((slot) => !snapshot.placements[slot.id]),
+    [slots, snapshot.placements],
+  );
   const taken = Object.keys(snapshot.placements).length;
   const entryBid = Math.min(
     ...slots.map((slot) => minimumBid(snapshot.placements[slot.id]?.amount)),
@@ -94,12 +98,10 @@ export default function AuctionSite() {
   );
   const filtered = useMemo(
     () =>
-      slots
+      openSlots
         .filter(
           (slot) =>
-            (filter === "all" ||
-              slot.face === filter ||
-              (filter === "available" && !snapshot.placements[slot.id])) &&
+            (filter === "all" || slot.face === filter) &&
             `${slot.name} ${slot.id} ${snapshot.placements[slot.id]?.brand || ""} ${snapshot.placements[slot.id]?.url || ""} ${snapshot.placements[slot.id]?.message || ""}`
               .toLowerCase()
               .includes(query.toLowerCase()),
@@ -107,7 +109,7 @@ export default function AuctionSite() {
         .sort((a, b) =>
           compareSlots(a, b, snapshot.placements, sort === "price"),
         ),
-    [filter, query, sort, snapshot.placements, slots],
+    [filter, openSlots, query, sort, snapshot.placements],
   );
   const displayed =
     showAll || filter !== "all" || query ? filtered : filtered.slice(0, 12);
@@ -390,11 +392,16 @@ export default function AuctionSite() {
               latest auction state loads.
             </p>
           )}
-          <div className="auction-toolbar">
+          {!openSlots.length && (
+            <div className="empty-search">
+              All seven spots are currently riding with us. Choose one on the
+              car above to outbid its current owner.
+            </div>
+          )}
+          <div className="auction-toolbar" hidden={!openSlots.length}>
             <div className="spot-filters" aria-label="Filter spots">
               {[
-                { id: "all", label: "All spots" },
-                { id: "available", label: "Unclaimed" },
+                { id: "all", label: "Open spots" },
                 ...views
                   .filter((v) => v.id !== "perspective")
                   .map((v) => ({ id: v.id, label: v.label })),
@@ -405,12 +412,12 @@ export default function AuctionSite() {
                   aria-pressed={filter === item.id}
                   onClick={() => {
                     setFilter(item.id);
-                    if (item.id !== "all" && item.id !== "available")
+                    if (item.id !== "all")
                       setManualView(item.id as View);
                   }}
                 >
                   {item.label}
-                  {item.id === "all" && <span>{slots.length}</span>}
+                  {item.id === "all" && <span>{openSlots.length}</span>}
                 </button>
               ))}
             </div>
@@ -424,7 +431,7 @@ export default function AuctionSite() {
               />
             </div>
           </div>
-          <div className="table-container">
+          <div className="table-container" hidden={!openSlots.length}>
             <table className="spots-table">
               <thead>
                 <tr>
@@ -557,13 +564,15 @@ export default function AuctionSite() {
               </div>
             )}
           </div>
-          <div className="table-footer">
+          <div className="table-footer" hidden={!openSlots.length}>
             <span>
               Showing {displayed.length} of {filtered.length} spots
             </span>
             {filter === "all" && !query && (
               <button onClick={() => setShowAll(!showAll)}>
-                {showAll ? "Show fewer spots" : `See all ${slots.length} spots`}
+                {showAll
+                  ? "Show fewer spots"
+                  : `See all ${openSlots.length} spots`}
                 <ChevronDown
                   size={15}
                   style={{ transform: showAll ? "rotate(180deg)" : undefined }}


### PR DESCRIPTION
## Summary
- remove occupied sponsorship spots from the auction table
- keep paid sponsors on the car and in the historical leaderboard
- show a clear outbid instruction when all seven spots are occupied

## Verification
- `npm run check` (54 tests, TypeScript, Next.js build, OpenNext Cloudflare Worker bundle)
- browser-verified locally using the current production auction snapshot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides occupied sponsorship spots from the auction table so bidders only see spots they can still claim.

- The table now lists only open spots; the "Unclaimed" filter is gone.
- Paid sponsors still appear on the car and in the historical leaderboard.
- When all seven spots are taken, a message directs bidders to pick a spot on the car to outbid its current owner.
- The toolbar, table, and footer are hidden when no spots are open.

<sup>Written for commit ad3fcc227e53de42a5b73013978c62d6edb18828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

