### PR TITLE
Hide empty auction controls

### DIFF
--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -398,7 +398,10 @@ export default function AuctionSite() {
               car above to outbid its current owner.
             </div>
           )}
-          <div className="auction-toolbar" hidden={!openSlots.length}>
+          <div
+            className="auction-toolbar"
+            style={!openSlots.length ? { display: "none" } : undefined}
+          >
             <div className="spot-filters" aria-label="Filter spots">
               {[
                 { id: "all", label: "Open spots" },
@@ -431,7 +434,10 @@ export default function AuctionSite() {
               />
             </div>
           </div>
-          <div className="table-container" hidden={!openSlots.length}>
+          <div
+            className="table-container"
+            style={!openSlots.length ? { display: "none" } : undefined}
+          >
             <table className="spots-table">
               <thead>
                 <tr>
@@ -564,7 +570,10 @@ export default function AuctionSite() {
               </div>
             )}
           </div>
-          <div className="table-footer" hidden={!openSlots.length}>
+          <div
+            className="table-footer"
+            style={!openSlots.length ? { display: "none" } : undefined}
+          >
             <span>
               Showing {displayed.length} of {filtered.length} spots
             </span>


### PR DESCRIPTION
## Summary
- fully hide the empty auction toolbar, table shell, and footer when every spot is occupied
- retain the concise instruction to choose a spot directly on the car

## Verification
- `npm run check` (54 tests, TypeScript, Next.js build, OpenNext Cloudflare Worker bundle)
- browser-verified with the current production auction snapshot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the auction toolbar, table shell, and footer when every spot is occupied so the page no longer shows empty controls.

- Replaces the `hidden` attribute with an inline `display: none` style, since `hidden` can be overridden by CSS.
- Keeps the instruction text telling users to choose a spot on the car.

<sup>Written for commit 32df3b22eaeb0d413ded08b3798a0ab1abf51d16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

