### PR TITLE
Restore auction leaderboard and Outbid buttons without spot numbers

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -628,20 +628,6 @@ input[type="checkbox"] {
   font-size: 12px;
   font-weight: 500;
 }
-.spot-swatch {
-  background: color-mix(in srgb, var(--spot-color) 38%, white);
-  border: 1px dashed color-mix(in srgb, var(--spot-color) 75%, #aaa);
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 37px;
-  height: 33px;
-  font-size: 12px;
-  letter-spacing: 0.4px;
-  color: #646a5e;
-  flex-shrink: 0;
-}
 .spot-title small {
   font-size: 12px;
   display: block;
@@ -680,6 +666,7 @@ input[type="checkbox"] {
   align-items: flex-start;
   gap: 5px;
   min-width: 0;
+  max-width: 100%;
 }
 .advertiser-copy > strong {
   font-size: 16px;
@@ -2036,11 +2023,6 @@ fieldset {
     font-size: 12px;
     gap: 9px;
     max-width: 190px;
-  }
-  .spot-swatch {
-    width: 30px;
-    height: 29px;
-    font-size: 10px;
   }
   .spot-title small {
     font-size: 10px;

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -85,10 +85,6 @@ export default function AuctionSite() {
     () => activeSlots(snapshot.placements),
     [snapshot.placements],
   );
-  const openSlots = useMemo(
-    () => slots.filter((slot) => !snapshot.placements[slot.id]),
-    [slots, snapshot.placements],
-  );
   const taken = Object.keys(snapshot.placements).length;
   const entryBid = Math.min(
     ...slots.map((slot) => minimumBid(snapshot.placements[slot.id]?.amount)),
@@ -98,10 +94,12 @@ export default function AuctionSite() {
   );
   const filtered = useMemo(
     () =>
-      openSlots
+      slots
         .filter(
           (slot) =>
-            (filter === "all" || slot.face === filter) &&
+            (filter === "all" ||
+              slot.face === filter ||
+              (filter === "available" && !snapshot.placements[slot.id])) &&
             `${slot.name} ${slot.id} ${snapshot.placements[slot.id]?.brand || ""} ${snapshot.placements[slot.id]?.url || ""} ${snapshot.placements[slot.id]?.message || ""}`
               .toLowerCase()
               .includes(query.toLowerCase()),
@@ -109,7 +107,7 @@ export default function AuctionSite() {
         .sort((a, b) =>
           compareSlots(a, b, snapshot.placements, sort === "price"),
         ),
-    [filter, openSlots, query, sort, snapshot.placements],
+    [filter, slots, query, sort, snapshot.placements],
   );
   const displayed =
     showAll || filter !== "all" || query ? filtered : filtered.slice(0, 12);
@@ -392,19 +390,11 @@ export default function AuctionSite() {
               latest auction state loads.
             </p>
           )}
-          {!openSlots.length && (
-            <div className="empty-search">
-              All seven spots are currently riding with us. Choose one on the
-              car above to outbid its current owner.
-            </div>
-          )}
-          <div
-            className="auction-toolbar"
-            style={!openSlots.length ? { display: "none" } : undefined}
-          >
+          <div className="auction-toolbar">
             <div className="spot-filters" aria-label="Filter spots">
               {[
-                { id: "all", label: "Open spots" },
+                { id: "all", label: "All spots" },
+                { id: "available", label: "Unclaimed" },
                 ...views
                   .filter((v) => v.id !== "perspective")
                   .map((v) => ({ id: v.id, label: v.label })),
@@ -415,12 +405,12 @@ export default function AuctionSite() {
                   aria-pressed={filter === item.id}
                   onClick={() => {
                     setFilter(item.id);
-                    if (item.id !== "all")
+                    if (item.id !== "all" && item.id !== "available")
                       setManualView(item.id as View);
                   }}
                 >
                   {item.label}
-                  {item.id === "all" && <span>{openSlots.length}</span>}
+                  {item.id === "all" && <span>{slots.length}</span>}
                 </button>
               ))}
             </div>
@@ -434,10 +424,7 @@ export default function AuctionSite() {
               />
             </div>
           </div>
-          <div
-            className="table-container"
-            style={!openSlots.length ? { display: "none" } : undefined}
-          >
+          <div className="table-container">
             <table className="spots-table">
               <thead>
                 <tr>
@@ -519,18 +506,8 @@ export default function AuctionSite() {
                         <button
                           className="spot-title"
                           onClick={() => choose(slot.id)}
-                          aria-label={`View spot ${slot.id.slice(3)}: ${slot.name}`}
+                          aria-label={`View ${slot.name}`}
                         >
-                          <span
-                            className="spot-swatch"
-                            style={
-                              {
-                                "--spot-color": slot.color,
-                              } as React.CSSProperties
-                            }
-                          >
-                            {slot.id.slice(3)}
-                          </span>
                           <span>
                             {slot.name}
                             <small>
@@ -570,10 +547,7 @@ export default function AuctionSite() {
               </div>
             )}
           </div>
-          <div
-            className="table-footer"
-            style={!openSlots.length ? { display: "none" } : undefined}
-          >
+          <div className="table-footer">
             <span>
               Showing {displayed.length} of {filtered.length} spots
             </span>
@@ -581,7 +555,7 @@ export default function AuctionSite() {
               <button onClick={() => setShowAll(!showAll)}>
                 {showAll
                   ? "Show fewer spots"
-                  : `See all ${openSlots.length} spots`}
+                  : `See all ${slots.length} spots`}
                 <ChevronDown
                   size={15}
                   style={{ transform: showAll ? "rotate(180deg)" : undefined }}


### PR DESCRIPTION
When every placement is occupied, the live auction hides all sponsor rows and their Outbid buttons. Restore occupied and unclaimed spots under “A little space. An open-ended race.” so visitors can open the purchase dialog directly from the table again.

Remove the numbered spot badges while retaining sponsor artwork, links, named locations, current bids, and the existing highest-bid-first order. Restore the All spots and Unclaimed filters, and constrain long sponsor links on mobile so they fit beside the payment buttons.

Validation: `npm run check` passes all 54 tests, TypeScript, the Next.js production build, and the OpenNext Worker bundle. Playwright checked all seven Outbid buttons at 1440px and 390px against the public auction data: every dialog selected the matching placement and defaulted to its current bid plus $1. Sponsor search, side filtering, the empty Unclaimed filter, and removal of numbered badges also passed. Desktop and mobile screenshots were visually inspected.

The local preview used live HTTP auction reads; production rejects its localhost WebSocket origin, so this verification exercised HTTP refresh. No purchase was submitted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the auction leaderboard and Outbid buttons when all spots are occupied. Previously a full auction hid every sponsor row and its Outbid button; now visitors can open the purchase dialog directly from the table again.

- Removes the numbered spot badges while keeping sponsor artwork, links, names, current bids, and the existing highest-bid-first order.
- Restores the All spots and Unclaimed filters and constrains long sponsor links on mobile so they fit beside the payment buttons.
- `npm run check` passes all 54 tests, TypeScript, the Next.js production build, and the OpenNext Worker bundle.
- Playwright verified all seven Outbid buttons at 1440px and 390px; each dialog selected the matching placement and defaulted to its current bid plus $1.
- The local preview used live HTTP auction reads; production rejects its localhost WebSocket origin, so no purchase was submitted.

<sup>Written for commit 8e33ef6e6c3c78b2418ffdbef2e6ba060d85710c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

