### PR TITLE
Make auction table Outbid buttons primary

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -744,18 +744,10 @@ input[type="checkbox"] {
 }
 .claim-button {
   font-size: 12px;
-  display: inline-flex;
-  align-items: center;
   gap: 8px;
-  border: 1px solid #dfe4d8;
   padding: 8px 12px;
   border-radius: 7px;
-  color: #67785a;
   white-space: nowrap;
-}
-.claim-button:hover {
-  background: #eef3e8;
-  border-color: #b5c6a5;
 }
 .sort-button {
   display: inline-flex;

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -528,7 +528,7 @@ export default function AuctionSite() {
                       </td>
                       <td>
                         <button
-                          className="claim-button"
+                          className="primary claim-button"
                           onClick={() => choose(slot.id)}
                           disabled={!loaded}
                         >


### PR DESCRIPTION
The auction table's pale outline buttons made occupied spots look unavailable. Use the existing solid primary-button style for Outbid and Claim spot so visitors can immediately see that they can purchase a placement.

Keep the compact table sizing and existing bid behavior. Remove the old outline colors so the shared primary hover style applies consistently.

Validation: `npm run check` passed (type checking, all 54 tests, and the OpenNext Cloudflare build). Browser checks at desktop and 390px mobile widths confirmed the solid styling, readable hover state, no page overflow, and that clicking Outbid or activating it with Enter opens the selected spot with the correct minimum bid. The local preview loaded current auction data over HTTP; its live WebSocket was rejected by the production origin check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The auction table's Outbid buttons now use the solid primary button style so occupied spots read as purchasable instead of unavailable. Removes the old outline colors and hover styling; compact sizing and existing bid behavior are unchanged. Validation passed via `npm run check` and browser checks at desktop and mobile widths.

<sup>Written for commit 2b72e69f2148621bd009957771d63c1225a79da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

