### PR TITLE
Focus Top view on the roof billboard

### DIFF
--- a/apps/website/src/components/car-viewer.tsx
+++ b/apps/website/src/components/car-viewer.tsx
@@ -102,7 +102,12 @@ function panelOutline(geometry: THREE.BufferGeometry) {
 }
 
 function frameCamera(state: Runtime, view: View, focus: string | null) {
-  const slot = focus ? slots.find((slot) => slot.id === focus) : undefined;
+  // The roof billboard is vertical: frame its artwork instead of looking down
+  // at its narrow top edge. Explicit placement previews keep their own focus.
+  const focusedSlot = focus ?? (view === "top" ? "ad-59" : null);
+  const slot = focusedSlot
+    ? slots.find((slot) => slot.id === focusedSlot)
+    : undefined;
   const panel = slot && state.model?.getObjectByName(slot.panel);
   const target = panel
     ? new THREE.Box3().setFromObject(panel).getCenter(new THREE.Vector3())


### PR DESCRIPTION
The Top button looked straight down, hiding the vertical billboard artwork after the model update. It now frames the billboard panel using the existing placement close-up camera, centering the artwork and fitting its width to the viewport. Explicit placement previews retain their selected focus.

Validation: TypeScript check and all 77 tests passed. Browser visual verification remains outstanding. Not deployed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Top camera view so the roof billboard artwork is framed instead of looking straight down at its narrow top edge. Explicit placement previews still keep their selected focus.

<sup>Written for commit 6b5328c7694b34c8ca1646b4b5c7a5a8286df218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

