### PR TITLE
Report a blank RUNPOD_API_KEY as missing

### DIFF
--- a/scripts/runpod_control.py
+++ b/scripts/runpod_control.py
@@ -37,7 +37,7 @@ def api_key():
         if line.strip().startswith("RUNPOD_API_KEY="):
             # .env.example ships the key blank; treat that as missing.
             values = shlex.split(line.split("=", 1)[1], comments=True)
-            if values:
+            if values and values[0].strip():
                 return values[0]
     raise RuntimeError("RUNPOD_API_KEY missing")
 

--- a/scripts/runpod_control.py
+++ b/scripts/runpod_control.py
@@ -31,9 +31,14 @@ class RunpodError(RuntimeError):
 def api_key():
     if os.environ.get("RUNPOD_API_KEY"):
         return os.environ["RUNPOD_API_KEY"]
-    for line in (ROOT / ".env").read_text().splitlines():
+    env_file = ROOT / ".env"
+    lines = env_file.read_text().splitlines() if env_file.exists() else []
+    for line in lines:
         if line.strip().startswith("RUNPOD_API_KEY="):
-            return shlex.split(line.split("=", 1)[1], comments=True)[0]
+            # .env.example ships the key blank; treat that as missing.
+            values = shlex.split(line.split("=", 1)[1], comments=True)
+            if values:
+                return values[0]
     raise RuntimeError("RUNPOD_API_KEY missing")
 
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -26,8 +26,9 @@ def test_blank_or_absent_key_is_reported_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(control, "ROOT", tmp_path)
     with pytest.raises(RuntimeError, match="RUNPOD_API_KEY missing"):
         control.api_key()
-    (tmp_path / ".env").write_text("RUNPOD_API_KEY=\n")
-    with pytest.raises(RuntimeError, match="RUNPOD_API_KEY missing"):
-        control.api_key()
+    for blank in ("RUNPOD_API_KEY=\n", 'RUNPOD_API_KEY=""\n', "RUNPOD_API_KEY=''\n"):
+        (tmp_path / ".env").write_text(blank)
+        with pytest.raises(RuntimeError, match="RUNPOD_API_KEY missing"):
+            control.api_key()
     (tmp_path / ".env").write_text("RUNPOD_API_KEY='abc'  # local\n")
     assert control.api_key() == "abc"

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 spec = importlib.util.spec_from_file_location("runpod_control", Path(__file__).parents[1] / "scripts/runpod_control.py")
 control = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(control)
@@ -17,3 +19,15 @@ def test_guard_limits_are_independent():
 def test_topup_does_not_extend_deadline():
     state = {"deadline_epoch": 100, "reserve_usd": 4, "initial_balance_usd": 20, "spend_cap_usd": 6}
     assert control.must_stop(state, 500, 100)
+
+
+def test_blank_or_absent_key_is_reported_missing(tmp_path, monkeypatch):
+    monkeypatch.delenv("RUNPOD_API_KEY", raising=False)
+    monkeypatch.setattr(control, "ROOT", tmp_path)
+    with pytest.raises(RuntimeError, match="RUNPOD_API_KEY missing"):
+        control.api_key()
+    (tmp_path / ".env").write_text("RUNPOD_API_KEY=\n")
+    with pytest.raises(RuntimeError, match="RUNPOD_API_KEY missing"):
+        control.api_key()
+    (tmp_path / ".env").write_text("RUNPOD_API_KEY='abc'  # local\n")
+    assert control.api_key() == "abc"


### PR DESCRIPTION
Copying `.env.example` unchanged leaves `RUNPOD_API_KEY=` empty. `api_key()` then crashes with `IndexError` (from `shlex.split('')[0]`) instead of the intended `RUNPOD_API_KEY missing` error. Without any `.env` it raises `FileNotFoundError`.

Both cases now fall through to the existing `RuntimeError`. Added a test in `tests/test_budget.py` covering no `.env`, a blank key, and a quoted key with a trailing comment.

`pytest` passes locally (10 passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `api_key()` in `scripts/runpod_control.py` so a blank or quoted-empty `RUNPOD_API_KEY` in `.env`, or a missing `.env` file, raises the intended `RUNPOD_API_KEY missing` error instead of crashing with `IndexError` or `FileNotFoundError`. Adds a test in `tests/test_budget.py` covering no `.env`, blank keys, and a quoted key with a trailing comment.

<sup>Written for commit 5d407d993ad23c04c049e26fd6bcfe99c4594706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

