### PR TITLE
Update sponsor disclaimer copy

### DIFF
--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -447,7 +447,9 @@ export default function AuctionSite() {
             </a>
           </div>
           <p className="hero-footnote">
-            Six legs. One steering wheel. A questionable business model.{" "}
+            We do not directly endorse any of the sponsors featured here. We do
+            not receive any ongoing benefits from any of the featured sponsors
+            and are not associated with any cryptocurrencies or coins.{" "}
             <a className="text-link" href="/media">
               Watch the fly <ArrowDown size={13} />
             </a>


### PR DESCRIPTION
## Summary
- Replace the hero tagline beneath the car with the requested sponsor disclaimer.
- Keep the existing Watch the fly link.

## Verification
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hero tagline with the new sponsor disclaimer copy, clarifying that the site does not endorse or benefit from featured sponsors. The existing "Watch the fly" link remains unchanged.

<sup>Written for commit 5254c831498c068788d9815183330dcb2c6381b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

