### PR TITLE
Make sponsor disclaimer more prominent

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -474,10 +474,34 @@ input[type="checkbox"] {
 .under-car > a {
   color: #515f45;
 }
-.hero-footnote {
-  font-size: 13px;
-  color: #65715e;
-  margin-top: 15px;
+.hero-disclaimer {
+  width: min(100%, 900px);
+  margin: 18px auto 0;
+  padding: 14px 18px 15px;
+  border: 1px solid #cbd8c3;
+  border-left: 4px solid var(--green);
+  border-radius: 10px;
+  background: #eff5e7;
+  color: var(--ink);
+  text-align: left;
+  box-shadow: 0 1px 3px #27321b0d;
+}
+.hero-disclaimer-label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--green);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.3px;
+}
+.hero-disclaimer p {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.55;
+}
+.hero-disclaimer p strong {
+  color: #284b26;
+  font-weight: 700;
 }
 .section-wrap {
   max-width: 1100px;
@@ -1918,9 +1942,27 @@ fieldset {
     gap: 4px;
     white-space: nowrap;
   }
-  .hero-footnote {
-    font-size: 10px;
+  .hero-disclaimer {
+    width: 100%;
     margin-top: 12px;
+    padding: 12px 12px 13px;
+  }
+  .hero-disclaimer-label {
+    margin-bottom: 5px;
+    font-size: 9px;
+    letter-spacing: 1.1px;
+  }
+  .hero-disclaimer p {
+    font-size: 12px;
+    line-height: 1.55;
+  }
+  .hero-disclaimer .text-link {
+    font-size: 12px;
+    margin-top: 9px;
+  }
+  .hero-disclaimer .text-link svg {
+    width: 12px;
+    height: 12px;
   }
   .section-wrap {
     margin-left: 20px;
@@ -2739,11 +2781,11 @@ fieldset {
 .media-teaser .primary {
   flex-shrink: 0;
 }
-.hero-footnote .text-link {
+.hero-disclaimer .text-link {
   display: inline-flex;
   gap: 4px;
   font-size: inherit;
-  margin-left: 6px;
+  margin-left: 0;
 }
 .media-journal {
   max-width: 1200px;

--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -6,6 +6,7 @@
   --soft: #f6f7f4;
   --ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);
   --duration-base: 240ms;
+  --duration-expand: 420ms;
   --shadow-elevated:
     0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06),
     0 10px 30px rgba(0, 0, 0, 0.06), 0 24px 60px rgba(0, 0, 0, 0.05);

--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -4,6 +4,11 @@
   --line: #e8e9e5;
   --green: #488443;
   --soft: #f6f7f4;
+  --ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);
+  --duration-base: 240ms;
+  --shadow-elevated:
+    0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06),
+    0 10px 30px rgba(0, 0, 0, 0.06), 0 24px 60px rgba(0, 0, 0, 0.05);
   --font:
     "DM Sans Variable", -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -446,14 +446,20 @@ export default function AuctionSite() {
               <ArrowDown size={14} />
             </a>
           </div>
-          <p className="hero-footnote">
-            We do not directly endorse any of the sponsors featured here. We do
-            not receive any ongoing benefits from any of the featured sponsors
-            and are not associated with any cryptocurrencies or coins.{" "}
+          <aside className="hero-disclaimer" aria-label="Sponsor disclaimer">
+            <span className="hero-disclaimer-label">SPONSOR DISCLAIMER</span>
+            <p>
+              We do not directly endorse any of the sponsors featured here. We
+              do not receive any ongoing benefits from any of the featured
+              sponsors and are{" "}
+              <strong>
+                not associated with any cryptocurrencies or coins.
+              </strong>
+            </p>
             <a className="text-link" href="/media">
               Watch the fly <ArrowDown size={13} />
             </a>
-          </p>
+          </aside>
         </section>
 
         <CustomWrapOffer snapshot={snapshot} loaded={loaded} accept={accept} />

--- a/apps/website/src/components/custom-wrap-offer.module.css
+++ b/apps/website/src/components/custom-wrap-offer.module.css
@@ -391,3 +391,315 @@
     transition: none;
   }
 }
+
+/* Keep the premium offer visible as a teaser, then return to the full card on hover. */
+.floating {
+  position: fixed;
+  z-index: 20;
+  right: 24px;
+  bottom: 24px;
+  width: min(300px, calc(100vw - 32px));
+  height: min(440px, calc(100dvh - 48px));
+  max-width: calc(100vw - 32px);
+  margin: 0;
+  padding: 0;
+  scroll-margin-top: 0;
+  transition:
+    width var(--duration-base) var(--ease-smooth),
+    height var(--duration-base) var(--ease-smooth);
+}
+.floating .shell {
+  height: 100%;
+  padding: 4px;
+  border-radius: 28px;
+  box-shadow: var(--shadow-elevated);
+}
+.floating .card {
+  height: 100%;
+  min-height: 0;
+  padding: 26px 24px 22px;
+  border-radius: 23px;
+  overflow: hidden;
+}
+.floating .topline {
+  align-items: flex-start;
+  gap: 8px;
+}
+.floating .badge {
+  max-width: 100%;
+  padding: 8px 10px;
+  gap: 6px;
+  overflow: hidden;
+  font-size: 8px;
+  letter-spacing: 1.1px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.floating .badge svg {
+  width: 12px;
+  flex-shrink: 0;
+}
+.floating .edition,
+.floating .pitch > p,
+.floating .signature,
+.floating .purchase .currency,
+.floating .includes,
+.floating .nextPrice,
+.floating .terms,
+.floating .notice,
+.floating .process,
+.floating .footer,
+.floating .status {
+  display: none;
+}
+.floating .content {
+  grid-template-columns: 1fr;
+  gap: 24px;
+  padding: 28px 0 22px;
+}
+.floating .pitch h2 {
+  font-size: 42px;
+  letter-spacing: -2.2px;
+}
+.floating .purchaseShell {
+  padding: 3px;
+  border-radius: 20px;
+}
+.floating .purchase {
+  padding: 18px 16px 15px;
+  border-radius: 17px;
+}
+.floating .priceLabel {
+  font-size: 8px;
+  letter-spacing: 1.4px;
+}
+.floating .price {
+  margin-top: 8px;
+  font-size: 48px;
+  letter-spacing: -2.5px;
+}
+.floating .cta {
+  padding: 7px 8px 7px 14px;
+  font-size: 12px;
+}
+.floating .cta > span {
+  width: 32px;
+  height: 32px;
+}
+.floating:is(:hover, :focus-within) {
+  width: min(1120px, calc(100vw - 48px));
+  height: auto;
+}
+.floating:is(:hover, :focus-within) .shell {
+  height: auto;
+  padding: 6px;
+  border-radius: 36px;
+  box-shadow: 0 18px 65px -32px #3d582d44;
+}
+.floating:is(:hover, :focus-within) .card {
+  height: auto;
+  min-height: initial;
+  padding: 38px 44px 28px;
+  border-radius: 30px;
+}
+.floating:is(:hover, :focus-within) .topline {
+  align-items: center;
+  gap: 20px;
+}
+.floating:is(:hover, :focus-within) .badge {
+  max-width: none;
+  padding: 9px 13px;
+  gap: 9px;
+  overflow: visible;
+  font-size: 10px;
+  letter-spacing: 1.7px;
+  white-space: normal;
+  text-overflow: clip;
+}
+.floating:is(:hover, :focus-within) .badge svg {
+  width: 14px;
+}
+.floating:is(:hover, :focus-within) .edition,
+.floating:is(:hover, :focus-within) .pitch > p,
+.floating:is(:hover, :focus-within) .signature,
+.floating:is(:hover, :focus-within) .purchase .currency,
+.floating:is(:hover, :focus-within) .includes,
+.floating:is(:hover, :focus-within) .nextPrice,
+.floating:is(:hover, :focus-within) .terms,
+.floating:is(:hover, :focus-within) .notice,
+.floating:is(:hover, :focus-within) .process,
+.floating:is(:hover, :focus-within) .footer,
+.floating:is(:hover, :focus-within) .status {
+  display: block;
+}
+.floating:is(:hover, :focus-within) .edition {
+  flex-shrink: 0;
+}
+.floating:is(:hover, :focus-within) .pitch > p {
+  max-width: 395px;
+  margin-top: 25px;
+  font-size: 16px;
+}
+.floating:is(:hover, :focus-within) .signature {
+  margin-top: 30px;
+}
+.floating:is(:hover, :focus-within) .includes {
+  display: grid;
+}
+.floating:is(:hover, :focus-within) .process {
+  display: flex;
+  gap: 28px;
+  padding: 27px 0 0;
+}
+.floating:is(:hover, :focus-within) .status {
+  display: flex;
+}
+.floating:is(:hover, :focus-within) .content {
+  grid-template-columns: 1.2fr 1fr;
+  gap: 54px;
+  align-items: center;
+  padding: 48px 0 52px;
+}
+.floating:is(:hover, :focus-within) .pitch h2 {
+  font-size: clamp(40px, 5vw, 66px);
+  letter-spacing: -3.4px;
+}
+.floating:is(:hover, :focus-within) .purchaseShell {
+  padding: 5px;
+  border-radius: 27px;
+}
+.floating:is(:hover, :focus-within) .purchase {
+  padding: 29px 28px 23px;
+  border-radius: 22px;
+}
+.floating:is(:hover, :focus-within) .priceLabel {
+  font-size: 10px;
+  letter-spacing: 1.9px;
+}
+.floating:is(:hover, :focus-within) .price {
+  font-size: clamp(42px, 5.1vw, 66px);
+  letter-spacing: -3.5px;
+}
+.floating:is(:hover, :focus-within) .cta {
+  padding: 9px 10px 9px 22px;
+  font-size: 15px;
+}
+.floating:is(:hover, :focus-within) .cta > span {
+  width: 35px;
+  height: 35px;
+}
+.floating:is(:hover, :focus-within) .currency {
+  font-size: 11px;
+  margin-top: 8px;
+}
+.floating:is(:hover, :focus-within) .includes {
+  gap: 12px;
+  margin: 25px 0;
+  font-size: 12px;
+}
+.floating:is(:hover, :focus-within) .nextPrice {
+  margin-top: 17px;
+  font-size: 11px;
+  line-height: 1.7;
+}
+.floating:is(:hover, :focus-within) .terms {
+  margin-top: 15px;
+  font-size: 10px;
+  line-height: 1.5;
+}
+.floating:is(:hover, :focus-within) .notice {
+  margin-top: 12px;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.floating:is(:hover, :focus-within) .footer {
+  margin-top: 26px;
+  font-size: 10px;
+  line-height: 1.7;
+}
+.floating:is(:hover, :focus-within) .status {
+  gap: 12px;
+  padding: 18px;
+  margin-top: 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+@media (max-width: 767px) {
+  .floating {
+    right: max(12px, env(safe-area-inset-right));
+    bottom: max(12px, env(safe-area-inset-bottom));
+    width: min(280px, calc(100vw - 24px));
+    height: min(410px, calc(100dvh - 32px));
+  }
+  .floating .card {
+    padding: 20px 18px 18px;
+  }
+  .floating .content {
+    gap: 20px;
+    padding: 22px 0 18px;
+  }
+  .floating .pitch h2 {
+    font-size: 36px;
+    letter-spacing: -1.8px;
+  }
+  .floating:is(:hover, :focus-within) {
+    width: min(960px, calc(100vw - 24px));
+    height: auto;
+  }
+  .floating:is(:hover, :focus-within) .card {
+    padding: 26px 20px 24px;
+    border-radius: 25px;
+  }
+  .floating:is(:hover, :focus-within) .content {
+    grid-template-columns: 1fr;
+    gap: 28px;
+    padding: 30px 0;
+  }
+  .floating:is(:hover, :focus-within) .pitch h2 {
+    font-size: clamp(38px, 9.5vw, 58px);
+    letter-spacing: -2px;
+  }
+  .floating:is(:hover, :focus-within) .pitch > p {
+    margin-top: 18px;
+    font-size: 14px;
+  }
+  .floating:is(:hover, :focus-within) .signature {
+    margin-top: 20px;
+    font-size: 8px;
+    letter-spacing: 1.5px;
+  }
+  .floating:is(:hover, :focus-within) .purchase {
+    padding: 25px 21px;
+  }
+  .floating:is(:hover, :focus-within) .price {
+    font-size: clamp(46px, 13vw, 64px);
+    letter-spacing: -2.5px;
+  }
+  .floating:is(:hover, :focus-within) .process {
+    flex-direction: column;
+    gap: 22px;
+    padding-top: 24px;
+  }
+  .floating:is(:hover, :focus-within) .process li {
+    gap: 16px;
+  }
+  .floating:is(:hover, :focus-within) .process strong {
+    font-size: 13px;
+  }
+  .floating:is(:hover, :focus-within) .process p {
+    font-size: 12px;
+  }
+  .floating:is(:hover, :focus-within) .footer {
+    font-size: 11px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating,
+  .floating .cta,
+  .floating .cta > span {
+    transition: none;
+  }
+}

--- a/apps/website/src/components/custom-wrap-offer.module.css
+++ b/apps/website/src/components/custom-wrap-offer.module.css
@@ -398,18 +398,20 @@
   z-index: 20;
   right: 24px;
   bottom: 24px;
+  display: grid;
+  grid-template-rows: minmax(440px, 0fr);
   width: min(300px, calc(100vw - 32px));
-  height: min(440px, calc(100dvh - 48px));
   max-width: calc(100vw - 32px);
   margin: 0;
   padding: 0;
   scroll-margin-top: 0;
   transition:
-    width var(--duration-base) var(--ease-smooth),
-    height var(--duration-base) var(--ease-smooth);
+    width var(--duration-expand) var(--ease-smooth),
+    grid-template-rows var(--duration-expand) var(--ease-smooth);
 }
 .floating .shell {
   height: 100%;
+  min-height: 0;
   padding: 4px;
   border-radius: 28px;
   box-shadow: var(--shadow-elevated);
@@ -488,17 +490,11 @@
 }
 .floating:is(:hover, :focus-within) {
   width: min(1120px, calc(100vw - 48px));
-  height: auto;
-}
-.floating:is(:hover, :focus-within) .shell {
-  height: auto;
-  padding: 6px;
-  border-radius: 36px;
-  box-shadow: 0 18px 65px -32px #3d582d44;
+  grid-template-rows: minmax(440px, 1fr);
 }
 .floating:is(:hover, :focus-within) .card {
-  height: auto;
-  min-height: initial;
+  height: 100%;
+  min-height: 0;
   padding: 38px 44px 28px;
   border-radius: 30px;
 }
@@ -630,8 +626,8 @@
   .floating {
     right: max(12px, env(safe-area-inset-right));
     bottom: max(12px, env(safe-area-inset-bottom));
+    grid-template-rows: minmax(410px, 0fr);
     width: min(280px, calc(100vw - 24px));
-    height: min(410px, calc(100dvh - 32px));
   }
   .floating .card {
     padding: 20px 18px 18px;
@@ -646,7 +642,7 @@
   }
   .floating:is(:hover, :focus-within) {
     width: min(960px, calc(100vw - 24px));
-    height: auto;
+    grid-template-rows: minmax(410px, 1fr);
   }
   .floating:is(:hover, :focus-within) .card {
     padding: 26px 20px 24px;

--- a/apps/website/src/components/custom-wrap-offer.module.css
+++ b/apps/website/src/components/custom-wrap-offer.module.css
@@ -481,6 +481,7 @@
   letter-spacing: -2.5px;
 }
 .floating .cta {
+  margin-top: 20px;
   padding: 7px 8px 7px 14px;
   font-size: 12px;
 }
@@ -577,6 +578,7 @@
   letter-spacing: -3.5px;
 }
 .floating:is(:hover, :focus-within) .cta {
+  margin-top: 0;
   padding: 9px 10px 9px 22px;
   font-size: 15px;
 }

--- a/apps/website/src/components/custom-wrap-offer.tsx
+++ b/apps/website/src/components/custom-wrap-offer.tsx
@@ -147,7 +147,7 @@ export default function CustomWrapOffer({
 
   return (
     <section
-      className={styles.section}
+      className={`${styles.section} ${styles.floating}`}
       id="custom-wrap"
       aria-labelledby="custom-wrap-title"
       ref={shell}


### PR DESCRIPTION
## Summary
- Turn the disclaimer beneath the car into a clearly labeled sponsor notice.
- Increase contrast and type size with a bordered, responsive notice panel.
- Emphasize that the project is not associated with cryptocurrencies or coins.
- Keep the existing Watch the fly link.

## Verification
- npm run typecheck
- git diff --check
- Local desktop and 390px mobile render checks; no horizontal overflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the sponsor footnote into a clearly labeled disclaimer panel and makes the custom wrap offer a floating card that expands on hover or focus.

- Adds a bordered, responsive notice with a "SPONSOR DISCLAIMER" label and larger, higher-contrast text.
- Boldly states the project is not associated with any cryptocurrencies or coins.
- Keeps the existing Watch the fly link and verifies no horizontal overflow at 390px mobile width.

**Refactors**
- The offer sits collapsed in the bottom-right corner as a teaser with breathing room above the CTA, and expands into the full card on hover or keyboard focus, with an eased transition and elevated shadow.
- The floating card adapts to mobile widths and disables transitions for reduced-motion users.

<sup>Written for commit 11970de0dbd5279c2412e2e6390b052fde3c2df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

