### PR TITLE
Make the buying CTAs prominent across the site

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -208,12 +208,64 @@ input[type="checkbox"] {
   margin-top: 21px;
   letter-spacing: -0.1px;
 }
+.hero-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 30px;
+}
+.hero-cta-button {
+  gap: 11px;
+  padding: 18px 34px;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  border-radius: 44px;
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+  box-shadow:
+    0 2px 5px #1f3b1d2b,
+    0 12px 28px #1f3b1d33;
+  transition:
+    background var(--duration-base) var(--ease-smooth),
+    border-color var(--duration-base) var(--ease-smooth),
+    box-shadow var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
+}
+.hero-cta-button svg {
+  transition: transform var(--duration-base) var(--ease-smooth);
+}
+.hero-cta-button:hover:not(:disabled) {
+  background: #3c7238;
+  border-color: #3c7238;
+  color: #fff;
+  box-shadow:
+    0 3px 8px #1f3b1d33,
+    0 18px 40px #1f3b1d40;
+  transform: translateY(-2px);
+}
+.hero-cta-button:hover:not(:disabled) svg {
+  transform: translate(3px, -3px);
+}
+.hero-cta-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow:
+    0 1px 3px #1f3b1d33,
+    0 6px 16px #1f3b1d2b;
+}
+.hero-cta-note {
+  font-size: 13px;
+  color: #65715e;
+  font-variant-numeric: tabular-nums;
+}
 .hero-stats {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 35px;
-  margin: 35px 0 32px;
+  margin: 32px 0;
 }
 .hero-stats > div {
   display: flex;
@@ -774,10 +826,41 @@ input[type="checkbox"] {
 }
 .claim-button {
   font-size: 12px;
+  font-weight: 600;
   gap: 8px;
-  padding: 8px 12px;
-  border-radius: 7px;
+  padding: 9px 15px;
+  border-radius: 8px;
   white-space: nowrap;
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+  box-shadow:
+    0 1px 2px #1f3b1d26,
+    0 4px 12px #1f3b1d24;
+  transition:
+    background var(--duration-base) var(--ease-smooth),
+    border-color var(--duration-base) var(--ease-smooth),
+    box-shadow var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
+}
+.claim-button svg {
+  transition: transform var(--duration-base) var(--ease-smooth);
+}
+.claim-button:hover:not(:disabled) {
+  background: #3c7238;
+  border-color: #3c7238;
+  color: #fff;
+  box-shadow:
+    0 2px 4px #1f3b1d2e,
+    0 8px 20px #1f3b1d38;
+  transform: translateY(-1px);
+}
+.claim-button:hover:not(:disabled) svg {
+  transform: translate(2px, -2px);
+}
+.claim-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px #1f3b1d33;
 }
 .sort-button {
   display: inline-flex;
@@ -1634,8 +1717,40 @@ fieldset {
 }
 .checkout-button {
   width: 100%;
-  font-size: 12px;
   margin-top: 9px;
+  padding: 15px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+  box-shadow:
+    0 1px 2px #1f3b1d26,
+    0 8px 20px #1f3b1d2e;
+  transition:
+    background var(--duration-base) var(--ease-smooth),
+    border-color var(--duration-base) var(--ease-smooth),
+    box-shadow var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
+}
+.checkout-button svg {
+  transition: transform var(--duration-base) var(--ease-smooth);
+}
+.checkout-button:hover:not(:disabled) {
+  background: #3c7238;
+  border-color: #3c7238;
+  color: #fff;
+  box-shadow:
+    0 2px 4px #1f3b1d2e,
+    0 12px 28px #1f3b1d3d;
+  transform: translateY(-1px);
+}
+.checkout-button:hover:not(:disabled) svg {
+  transform: translate(2px, -2px);
+}
+.checkout-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px #1f3b1d33;
 }
 .stripe-note {
   display: flex;
@@ -1865,6 +1980,19 @@ fieldset {
     line-height: 1.8;
     margin: 14px auto 0;
     max-width: 285px;
+  }
+  .hero-cta {
+    margin-top: 22px;
+    gap: 10px;
+  }
+  .hero-cta-button {
+    width: 100%;
+    max-width: 320px;
+    padding: 16px 26px;
+    font-size: 15px;
+  }
+  .hero-cta-note {
+    font-size: 11px;
   }
   .hero-stats {
     display: grid;

--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -128,6 +128,10 @@ export default function AuctionSite() {
   const displayed =
     showAll || filter !== "all" || query ? filtered : filtered.slice(0, 12);
   const highestBid = rankPlacements(snapshot.placements)[0];
+  // The hero CTA aims at the priciest placement, and falls back to the cheapest
+  // way onto the car while the livery is still empty.
+  const heroSlot =
+    slots.find((slot) => slot.id === highestBid?.slotId) || entrySlot;
   const fundingTarget = 100_000;
   const fundingPercent = (snapshot.totalRaised / fundingTarget) * 100;
   const fundingLabel = `${Number(fundingPercent.toFixed(1))}%`;
@@ -295,7 +299,9 @@ export default function AuctionSite() {
       <a href="#live-auction" className="skip-link">
         Skip to ad spaces
       </a>
-      <SiteHeader />
+      <SiteHeader
+        onQuickBuy={loaded && heroSlot ? () => choose(heroSlot.id) : undefined}
+      />
       <main>
         <section className="hero">
           <div className="live-indicator">
@@ -333,6 +339,25 @@ export default function AuctionSite() {
             We’re teaching a fly to drive. Your logo can come along for the
             ride.
           </p>
+          <div className="hero-cta">
+            <button
+              type="button"
+              className="primary hero-cta-button"
+              disabled={!loaded || !heroSlot}
+              aria-haspopup="dialog"
+              onClick={() => heroSlot && choose(heroSlot.id)}
+            >
+              Add my logo
+              <ArrowUpRight size={19} />
+            </button>
+            <span className="hero-cta-note">
+              {loaded
+                ? highestBid
+                  ? `Take the top spot from ${highestBid.brand} · ${money(minimumBid(highestBid.amount))} or more`
+                  : `${slots.length - taken} of ${slots.length} spots open · from ${money(entryBid)}`
+                : "Loading the live auction…"}
+            </span>
+          </div>
           <div className="hero-stats">
             <div>
               <strong>{loaded ? money(snapshot.totalRaised) : "—"}</strong>

--- a/apps/website/src/components/car-ad-preview.module.css
+++ b/apps/website/src/components/car-ad-preview.module.css
@@ -3,7 +3,7 @@
   top: 64px;
   right: 24px;
   z-index: 2;
-  width: 264px;
+  width: 300px;
   max-height: calc(100% - 132px);
   overflow-y: auto;
   padding: 16px;
@@ -79,28 +79,83 @@
 }
 
 .claim {
-  display: block;
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   width: 100%;
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid #e4e9dd;
-  text-align: left;
-  font-size: 12px;
-  line-height: 1.5;
-  color: #42652c;
+  margin-top: 16px;
+  padding: 13px 14px;
+  border-radius: 10px;
+  background: var(--green);
+  color: #fff;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+  text-wrap: balance;
+  box-shadow:
+    0 1px 2px #1f3b1d26,
+    0 6px 16px #1f3b1d2e,
+    0 16px 0 16px rgb(255 255 255 / 97%);
+  transition:
+    background var(--duration-base) var(--ease-smooth),
+    box-shadow var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
+}
+
+.claim span {
+  transition: transform var(--duration-base) var(--ease-smooth);
 }
 
 .claim:hover {
-  text-decoration: underline;
+  background: #3c7238;
+  box-shadow:
+    0 2px 4px #1f3b1d2e,
+    0 10px 24px #1f3b1d3d,
+    0 16px 0 16px rgb(255 255 255 / 97%);
+  transform: translateY(-1px);
+}
+
+.claim:hover span {
+  transform: translate(2px, -2px);
+}
+
+.claim:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow:
+    0 1px 2px #1f3b1d33,
+    0 16px 0 16px rgb(255 255 255 / 97%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .claim,
+  .claim span {
+    transition: none;
+  }
+  .claim:hover {
+    transform: none;
+  }
+  .claim:hover span {
+    transform: none;
+  }
 }
 
 @media (max-width: 600px) {
   .preview {
     top: 48px;
     right: 12px;
-    width: 220px;
+    width: 252px;
   }
   .artwork {
     height: 80px;
+  }
+  .claim {
+    margin-top: 14px;
+    padding: 12px;
+    font-size: 12.5px;
   }
 }

--- a/apps/website/src/components/custom-wrap-offer.module.css
+++ b/apps/website/src/components/custom-wrap-offer.module.css
@@ -392,6 +392,58 @@
   }
 }
 
+/* The pill is the resting state once the page is in motion: small, calm, still selling. */
+.pill {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 7px 0 17px;
+  border: 1px solid #ffffff1f;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #1d2a1a, #101709 70%);
+  color: #f4f8ee;
+  box-shadow: var(--shadow-elevated);
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity var(--duration-base) var(--ease-smooth),
+    visibility var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
+}
+.pillLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  font-weight: 550;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #cfe0bd;
+  white-space: nowrap;
+}
+.pillPrice {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px 8px 14px;
+  border-radius: 999px;
+  background: #d9efba;
+  color: #17240f;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.2px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.pill:hover .pillPrice {
+  background: #e7f6cf;
+}
+
 /* Keep the premium offer visible as a teaser, then return to the full card on hover. */
 .floating {
   position: fixed;
@@ -415,6 +467,10 @@
   padding: 4px;
   border-radius: 28px;
   box-shadow: var(--shadow-elevated);
+  transition:
+    opacity var(--duration-base) var(--ease-smooth),
+    visibility var(--duration-base) var(--ease-smooth),
+    transform var(--duration-base) var(--ease-smooth);
 }
 .floating .card {
   height: 100%;
@@ -489,21 +545,21 @@
   width: 32px;
   height: 32px;
 }
-.floating:is(:hover, :focus-within) {
+.floating:is(:hover, :focus-within, [data-open="true"]) {
   width: min(1120px, calc(100vw - 48px));
   grid-template-rows: minmax(440px, 1fr);
 }
-.floating:is(:hover, :focus-within) .card {
+.floating:is(:hover, :focus-within, [data-open="true"]) .card {
   height: 100%;
   min-height: 0;
   padding: 38px 44px 28px;
   border-radius: 30px;
 }
-.floating:is(:hover, :focus-within) .topline {
+.floating:is(:hover, :focus-within, [data-open="true"]) .topline {
   align-items: center;
   gap: 20px;
 }
-.floating:is(:hover, :focus-within) .badge {
+.floating:is(:hover, :focus-within, [data-open="true"]) .badge {
   max-width: none;
   padding: 9px 13px;
   gap: 9px;
@@ -513,115 +569,138 @@
   white-space: normal;
   text-overflow: clip;
 }
-.floating:is(:hover, :focus-within) .badge svg {
+.floating:is(:hover, :focus-within, [data-open="true"]) .badge svg {
   width: 14px;
 }
-.floating:is(:hover, :focus-within) .edition,
-.floating:is(:hover, :focus-within) .pitch > p,
-.floating:is(:hover, :focus-within) .signature,
-.floating:is(:hover, :focus-within) .purchase .currency,
-.floating:is(:hover, :focus-within) .includes,
-.floating:is(:hover, :focus-within) .nextPrice,
-.floating:is(:hover, :focus-within) .terms,
-.floating:is(:hover, :focus-within) .notice,
-.floating:is(:hover, :focus-within) .process,
-.floating:is(:hover, :focus-within) .footer,
-.floating:is(:hover, :focus-within) .status {
+.floating:is(:hover, :focus-within, [data-open="true"]) .edition,
+.floating:is(:hover, :focus-within, [data-open="true"]) .pitch > p,
+.floating:is(:hover, :focus-within, [data-open="true"]) .signature,
+.floating:is(:hover, :focus-within, [data-open="true"]) .purchase .currency,
+.floating:is(:hover, :focus-within, [data-open="true"]) .includes,
+.floating:is(:hover, :focus-within, [data-open="true"]) .nextPrice,
+.floating:is(:hover, :focus-within, [data-open="true"]) .terms,
+.floating:is(:hover, :focus-within, [data-open="true"]) .notice,
+.floating:is(:hover, :focus-within, [data-open="true"]) .process,
+.floating:is(:hover, :focus-within, [data-open="true"]) .footer,
+.floating:is(:hover, :focus-within, [data-open="true"]) .status {
   display: block;
 }
-.floating:is(:hover, :focus-within) .edition {
+.floating:is(:hover, :focus-within, [data-open="true"]) .edition {
   flex-shrink: 0;
 }
-.floating:is(:hover, :focus-within) .pitch > p {
+.floating:is(:hover, :focus-within, [data-open="true"]) .pitch > p {
   max-width: 395px;
   margin-top: 25px;
   font-size: 16px;
 }
-.floating:is(:hover, :focus-within) .signature {
+.floating:is(:hover, :focus-within, [data-open="true"]) .signature {
   margin-top: 30px;
 }
-.floating:is(:hover, :focus-within) .includes {
+.floating:is(:hover, :focus-within, [data-open="true"]) .includes {
   display: grid;
 }
-.floating:is(:hover, :focus-within) .process {
+.floating:is(:hover, :focus-within, [data-open="true"]) .process {
   display: flex;
   gap: 28px;
   padding: 27px 0 0;
 }
-.floating:is(:hover, :focus-within) .status {
+.floating:is(:hover, :focus-within, [data-open="true"]) .status {
   display: flex;
 }
-.floating:is(:hover, :focus-within) .content {
+.floating:is(:hover, :focus-within, [data-open="true"]) .content {
   grid-template-columns: 1.2fr 1fr;
   gap: 54px;
   align-items: center;
   padding: 48px 0 52px;
 }
-.floating:is(:hover, :focus-within) .pitch h2 {
+.floating:is(:hover, :focus-within, [data-open="true"]) .pitch h2 {
   font-size: clamp(40px, 5vw, 66px);
   letter-spacing: -3.4px;
 }
-.floating:is(:hover, :focus-within) .purchaseShell {
+.floating:is(:hover, :focus-within, [data-open="true"]) .purchaseShell {
   padding: 5px;
   border-radius: 27px;
 }
-.floating:is(:hover, :focus-within) .purchase {
+.floating:is(:hover, :focus-within, [data-open="true"]) .purchase {
   padding: 29px 28px 23px;
   border-radius: 22px;
 }
-.floating:is(:hover, :focus-within) .priceLabel {
+.floating:is(:hover, :focus-within, [data-open="true"]) .priceLabel {
   font-size: 10px;
   letter-spacing: 1.9px;
 }
-.floating:is(:hover, :focus-within) .price {
+.floating:is(:hover, :focus-within, [data-open="true"]) .price {
   font-size: clamp(42px, 5.1vw, 66px);
   letter-spacing: -3.5px;
 }
-.floating:is(:hover, :focus-within) .cta {
+.floating:is(:hover, :focus-within, [data-open="true"]) .cta {
   margin-top: 0;
   padding: 9px 10px 9px 22px;
   font-size: 15px;
 }
-.floating:is(:hover, :focus-within) .cta > span {
+.floating:is(:hover, :focus-within, [data-open="true"]) .cta > span {
   width: 35px;
   height: 35px;
 }
-.floating:is(:hover, :focus-within) .currency {
+.floating:is(:hover, :focus-within, [data-open="true"]) .currency {
   font-size: 11px;
   margin-top: 8px;
 }
-.floating:is(:hover, :focus-within) .includes {
+.floating:is(:hover, :focus-within, [data-open="true"]) .includes {
   gap: 12px;
   margin: 25px 0;
   font-size: 12px;
 }
-.floating:is(:hover, :focus-within) .nextPrice {
+.floating:is(:hover, :focus-within, [data-open="true"]) .nextPrice {
   margin-top: 17px;
   font-size: 11px;
   line-height: 1.7;
 }
-.floating:is(:hover, :focus-within) .terms {
+.floating:is(:hover, :focus-within, [data-open="true"]) .terms {
   margin-top: 15px;
   font-size: 10px;
   line-height: 1.5;
 }
-.floating:is(:hover, :focus-within) .notice {
+.floating:is(:hover, :focus-within, [data-open="true"]) .notice {
   margin-top: 12px;
   padding: 10px 12px;
   font-size: 12px;
   line-height: 1.5;
 }
-.floating:is(:hover, :focus-within) .footer {
+.floating:is(:hover, :focus-within, [data-open="true"]) .footer {
   margin-top: 26px;
   font-size: 10px;
   line-height: 1.7;
 }
-.floating:is(:hover, :focus-within) .status {
+.floating:is(:hover, :focus-within, [data-open="true"]) .status {
   gap: 12px;
   padding: 18px;
   margin-top: 24px;
   font-size: 14px;
   line-height: 1.6;
+}
+
+/* Shrunk to a pill: after the first scroll on desktop, always on phones. */
+.floating[data-collapsed="true"]:not(
+    :hover,
+    :focus-within,
+    [data-open="true"]
+  ) {
+  width: 258px;
+  grid-template-rows: minmax(54px, 0fr);
+}
+.floating[data-collapsed="true"]:not(:hover, :focus-within, [data-open="true"])
+  .shell {
+  visibility: hidden;
+  opacity: 0;
+  transform: scale(0.97);
+  pointer-events: none;
+}
+.floating[data-collapsed="true"]:not(:hover, :focus-within, [data-open="true"])
+  .pill {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 @media (max-width: 767px) {
@@ -630,6 +709,32 @@
     bottom: max(12px, env(safe-area-inset-bottom));
     grid-template-rows: minmax(410px, 0fr);
     width: min(280px, calc(100vw - 24px));
+  }
+  /* Phones never get the big teaser: the pill is the resting state. */
+  .floating:not(:hover, :focus-within, [data-open="true"]) {
+    width: min(232px, calc(100vw - 24px));
+    grid-template-rows: minmax(48px, 0fr);
+  }
+  .floating:not(:hover, :focus-within, [data-open="true"]) .shell {
+    visibility: hidden;
+    opacity: 0;
+    transform: scale(0.97);
+    pointer-events: none;
+  }
+  .floating:not(:hover, :focus-within, [data-open="true"]) .pill {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .pill {
+    padding: 0 6px 0 14px;
+  }
+  .pillLabel {
+    font-size: 10px;
+  }
+  .pillPrice {
+    padding: 7px 10px 7px 12px;
+    font-size: 12px;
   }
   .floating .card {
     padding: 20px 18px 18px;
@@ -642,54 +747,59 @@
     font-size: 36px;
     letter-spacing: -1.8px;
   }
-  .floating:is(:hover, :focus-within) {
+  .floating:is(:hover, :focus-within, [data-open="true"]) {
     width: min(960px, calc(100vw - 24px));
     grid-template-rows: minmax(410px, 1fr);
+    max-height: calc(100dvh - 24px);
   }
-  .floating:is(:hover, :focus-within) .card {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .card {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+  .floating:is(:hover, :focus-within, [data-open="true"]) .card {
     padding: 26px 20px 24px;
     border-radius: 25px;
   }
-  .floating:is(:hover, :focus-within) .content {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .content {
     grid-template-columns: 1fr;
     gap: 28px;
     padding: 30px 0;
   }
-  .floating:is(:hover, :focus-within) .pitch h2 {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .pitch h2 {
     font-size: clamp(38px, 9.5vw, 58px);
     letter-spacing: -2px;
   }
-  .floating:is(:hover, :focus-within) .pitch > p {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .pitch > p {
     margin-top: 18px;
     font-size: 14px;
   }
-  .floating:is(:hover, :focus-within) .signature {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .signature {
     margin-top: 20px;
     font-size: 8px;
     letter-spacing: 1.5px;
   }
-  .floating:is(:hover, :focus-within) .purchase {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .purchase {
     padding: 25px 21px;
   }
-  .floating:is(:hover, :focus-within) .price {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .price {
     font-size: clamp(46px, 13vw, 64px);
     letter-spacing: -2.5px;
   }
-  .floating:is(:hover, :focus-within) .process {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .process {
     flex-direction: column;
     gap: 22px;
     padding-top: 24px;
   }
-  .floating:is(:hover, :focus-within) .process li {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .process li {
     gap: 16px;
   }
-  .floating:is(:hover, :focus-within) .process strong {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .process strong {
     font-size: 13px;
   }
-  .floating:is(:hover, :focus-within) .process p {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .process p {
     font-size: 12px;
   }
-  .floating:is(:hover, :focus-within) .footer {
+  .floating:is(:hover, :focus-within, [data-open="true"]) .footer {
     font-size: 11px;
   }
 }

--- a/apps/website/src/components/custom-wrap-offer.tsx
+++ b/apps/website/src/components/custom-wrap-offer.tsx
@@ -21,6 +21,32 @@ export default function CustomWrapOffer({
   const [error, setError] = useState("");
   const request = useRef<{ id: string; amount: number } | null>(null);
   const shell = useRef<HTMLElement>(null);
+  const [collapsed, setCollapsed] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  // The teaser card greets the top of the page, then gets out of the way.
+  useEffect(() => {
+    const update = () => setCollapsed(window.scrollY > 120);
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    return () => window.removeEventListener("scroll", update);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: Event) => {
+      if (!shell.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", close);
+    document.addEventListener("keydown", escape);
+    return () => {
+      document.removeEventListener("pointerdown", close);
+      document.removeEventListener("keydown", escape);
+    };
+  }, [open]);
 
   useEffect(() => {
     const element = shell.current;
@@ -151,7 +177,24 @@ export default function CustomWrapOffer({
       id="custom-wrap"
       aria-labelledby="custom-wrap-title"
       ref={shell}
+      data-collapsed={collapsed ? "true" : "false"}
+      data-open={open ? "true" : "false"}
     >
+      <button
+        type="button"
+        className={styles.pill}
+        aria-expanded={open}
+        aria-label="Open the full custom wrap offer"
+        onClick={() => setOpen(true)}
+      >
+        <span className={styles.pillLabel}>
+          <Sparkles size={13} strokeWidth={1.4} /> Custom wrap
+        </span>
+        <span className={styles.pillPrice}>
+          {loaded ? money(offer.amount) : "$10,000"}
+          <ArrowUpRight size={13} />
+        </span>
+      </button>
       <div className={styles.shell}>
         <div className={styles.card}>
           <div className={styles.sheen} aria-hidden="true" />

--- a/apps/website/src/components/site-header.tsx
+++ b/apps/website/src/components/site-header.tsx
@@ -3,8 +3,10 @@ import FlyMark from "./fly-mark";
 
 export default function SiteHeader({
   currentPage = "home",
+  onQuickBuy,
 }: {
   currentPage?: "home" | "media" | "press";
+  onQuickBuy?: () => void;
 }) {
   const home = currentPage === "home" ? "" : "/";
   return (
@@ -34,9 +36,20 @@ export default function SiteHeader({
           Press kit
         </a>
       </nav>
-      <a className="primary header-cta" href={`${home}#live-auction`}>
-        Get a spot <ArrowUpRight size={16} />
-      </a>
+      {onQuickBuy ? (
+        <button
+          type="button"
+          className="primary header-cta"
+          aria-haspopup="dialog"
+          onClick={onQuickBuy}
+        >
+          Get a spot <ArrowUpRight size={16} />
+        </button>
+      ) : (
+        <a className="primary header-cta" href={`${home}#live-auction`}>
+          Get a spot <ArrowUpRight size={16} />
+        </a>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## What changed

Every way onto the car now reads as a call to action, and the floating custom wrap card stops covering those actions.

**Hover card on the 3D viewer.** The claim link is a filled green button. It sticks to the bottom of the card so it stays reachable when the card scrolls on short viewports, with a white band hiding content passing under it. The card went from 264 to 300 pixels wide, and 220 to 252 on phones, so the label and its arrow fit on one line.

**Auction table and bid dialog.** The Outbid / Claim spot buttons and the dialog's checkout button move from ink to green, sharing one hover language: darken, lift a pixel, nudge the arrow up and right.

**Hero.** A large "Add my logo" button sits under the subtitle, above the stats. Under it, a live line says how many spots are open and what they cost. It opens the bid dialog on the placement with the highest current bid, and falls back to the cheapest way onto the car while the livery is empty. The header's "Get a spot" button opens the same dialog on the home page.

**Custom wrap card.** It is fixed to the bottom right and was covering the hero stats and the table's action column. It now shrinks to a small pill once the page scrolls past 120 pixels, and is always a pill on phones. Hover expands it on desktop; tapping expands it on phones, where it is capped to the screen height and scrolls internally. Tapping outside or pressing Escape closes it.

## Why

The claim and outbid actions were plain text links or small dark chips, easy to miss on a page whose whole purpose is selling ad spots. The hero had no primary action at all.

## Notes for review

- The header CTA takes an optional handler. The media and press pages pass none, so it stays a link to the live auction section there, as does the home page before auction data loads.
- All hover motion is off under `prefers-reduced-motion`.
- Verified in a local dev server: teaser to pill on scroll, pill expansion by hover and by tap, the hero and header buttons both opening the dialog on the top-bid spot, and the table with no overlap. The top-bid targeting was checked against a stubbed auction with three sponsors, since the local worker's auction is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes every way onto the car read as a call to action instead of a text link or dark chip. The claim, outbid, and checkout buttons become filled green buttons with a shared hover language, the hero gains an "Add my logo" button that opens the bid dialog on the top-bid placement (falling back to the cheapest spot while the livery is empty), and the floating custom wrap card shrinks to a pill on scroll so it stops covering the hero stats and auction table.

**Custom wrap card**
- Collapses to a pill after scrolling past 120px on desktop; always a pill on phones.
- Hover expands it on desktop; tap expands it on phones, capped to the screen height with internal scroll.
- Tapping outside or pressing Escape closes it.

**Header CTA**
- "Get a spot" opens the bid dialog on the home page; media and press pages keep it as a link to the auction section.

<sup>Written for commit 974da0a5e2793bdd1f56ddfc54a1d518db8a235c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

