### PR TITLE
Trim the sponsor disclaimer to the crypto line

### DIFF
--- a/apps/website/src/components/auction-site.tsx
+++ b/apps/website/src/components/auction-site.tsx
@@ -474,11 +474,8 @@ export default function AuctionSite() {
           <aside className="hero-disclaimer" aria-label="Sponsor disclaimer">
             <span className="hero-disclaimer-label">SPONSOR DISCLAIMER</span>
             <p>
-              We do not directly endorse any of the sponsors featured here. We
-              do not receive any ongoing benefits from any of the featured
-              sponsors and are{" "}
               <strong>
-                not associated with any cryptocurrencies or coins.
+                We are not associated with any cryptocurrencies or coins.
               </strong>
             </p>
             <a className="text-link" href="/media">


### PR DESCRIPTION
The hero sponsor disclaimer now reads only:

> We are not associated with any cryptocurrencies or coins.

The endorsement sentence and the ongoing-benefits sentence are removed. The label, the surrounding layout, and the "Watch the fly" link are unchanged.

Typecheck and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the hero sponsor disclaimer down to only the crypto disclaimer line, removing the endorsement and ongoing-benefits sentences. The label, layout, and "Watch the fly" link are unchanged.

<sup>Written for commit b8d1a70c3410ba3b44be15a36a15e25a15442323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MarkUnthank/flyhard/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

